### PR TITLE
支持基于分隔符切分SQL片段

### DIFF
--- a/block.go
+++ b/block.go
@@ -1,0 +1,77 @@
+package parser
+
+import "strings"
+
+type Block interface {
+	MatchBegin(tokenType int, token *yySymType) bool
+	MatchEnd(tokenType int, token *yySymType) bool
+}
+
+var allBlocks []Block = []Block{
+	BeginEndBlock{},
+	IfEndIfBlock{},
+	CaseEndCaseBlock{},
+	RepeatEndRepeatBlock{},
+	WhileEndWhileBlock{},
+	LoopEndLoopBlock{},
+}
+
+type LoopEndLoopBlock struct{}
+
+func (b BeginEndBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == begin
+}
+
+func (b BeginEndBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return true
+}
+
+type IfEndIfBlock struct{}
+
+func (b IfEndIfBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == ifKwd
+}
+
+func (b IfEndIfBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return tokenType == ifKwd
+}
+
+type CaseEndCaseBlock struct{}
+
+func (b CaseEndCaseBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == caseKwd
+}
+
+func (b CaseEndCaseBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return tokenType == caseKwd
+}
+
+type RepeatEndRepeatBlock struct{}
+
+func (b RepeatEndRepeatBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == repeat
+}
+
+func (b RepeatEndRepeatBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return tokenType == repeat
+}
+
+type WhileEndWhileBlock struct{}
+
+func (b WhileEndWhileBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == identifier && strings.ToUpper(token.ident) == "WHILE"
+}
+
+func (b WhileEndWhileBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return tokenType == identifier && strings.ToUpper(token.ident) == "WHILE"
+}
+
+type BeginEndBlock struct{}
+
+func (b LoopEndLoopBlock) MatchBegin(tokenType int, token *yySymType) bool {
+	return tokenType == identifier && strings.ToUpper(token.ident) == "LOOP"
+}
+
+func (b LoopEndLoopBlock) MatchEnd(tokenType int, token *yySymType) bool {
+	return tokenType == identifier && strings.ToUpper(token.ident) == "LOOP"
+}

--- a/block.go
+++ b/block.go
@@ -3,8 +3,16 @@ package parser
 import "strings"
 
 type Block interface {
-	MatchBegin(tokenType int, token *yySymType) bool
-	MatchEnd(tokenType int, token *yySymType) bool
+	MatchBegin(token *Token) bool
+	MatchEnd(token *Token) bool
+}
+
+type Blocker struct {
+	Scanner *Scanner
+}
+
+func NewBlocker() *Blocker {
+	return &Blocker{}
 }
 
 var allBlocks []Block = []Block{
@@ -18,60 +26,60 @@ var allBlocks []Block = []Block{
 
 type LoopEndLoopBlock struct{}
 
-func (b BeginEndBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == begin
+func (b BeginEndBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == begin
 }
 
-func (b BeginEndBlock) MatchEnd(tokenType int, token *yySymType) bool {
+func (b BeginEndBlock) MatchEnd(token *Token) bool {
 	return true
 }
 
 type IfEndIfBlock struct{}
 
-func (b IfEndIfBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == ifKwd
+func (b IfEndIfBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == ifKwd
 }
 
-func (b IfEndIfBlock) MatchEnd(tokenType int, token *yySymType) bool {
-	return tokenType == ifKwd
+func (b IfEndIfBlock) MatchEnd(token *Token) bool {
+	return token.tokenType == ifKwd
 }
 
 type CaseEndCaseBlock struct{}
 
-func (b CaseEndCaseBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == caseKwd
+func (b CaseEndCaseBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == caseKwd
 }
 
-func (b CaseEndCaseBlock) MatchEnd(tokenType int, token *yySymType) bool {
-	return tokenType == caseKwd
+func (b CaseEndCaseBlock) MatchEnd(token *Token) bool {
+	return token.tokenType == caseKwd
 }
 
 type RepeatEndRepeatBlock struct{}
 
-func (b RepeatEndRepeatBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == repeat
+func (b RepeatEndRepeatBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == repeat
 }
 
-func (b RepeatEndRepeatBlock) MatchEnd(tokenType int, token *yySymType) bool {
-	return tokenType == repeat
+func (b RepeatEndRepeatBlock) MatchEnd(token *Token) bool {
+	return token.tokenType == repeat
 }
 
 type WhileEndWhileBlock struct{}
 
-func (b WhileEndWhileBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == identifier && strings.ToUpper(token.ident) == "WHILE"
+func (b WhileEndWhileBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == identifier && strings.ToUpper(token.tokenValue.ident) == "WHILE"
 }
 
-func (b WhileEndWhileBlock) MatchEnd(tokenType int, token *yySymType) bool {
-	return tokenType == identifier && strings.ToUpper(token.ident) == "WHILE"
+func (b WhileEndWhileBlock) MatchEnd(token *Token) bool {
+	return token.tokenType == identifier && strings.ToUpper(token.tokenValue.ident) == "WHILE"
 }
 
 type BeginEndBlock struct{}
 
-func (b LoopEndLoopBlock) MatchBegin(tokenType int, token *yySymType) bool {
-	return tokenType == identifier && strings.ToUpper(token.ident) == "LOOP"
+func (b LoopEndLoopBlock) MatchBegin(token *Token) bool {
+	return token.tokenType == identifier && strings.ToUpper(token.tokenValue.ident) == "LOOP"
 }
 
-func (b LoopEndLoopBlock) MatchEnd(tokenType int, token *yySymType) bool {
-	return tokenType == identifier && strings.ToUpper(token.ident) == "LOOP"
+func (b LoopEndLoopBlock) MatchEnd(token *Token) bool {
+	return token.tokenType == identifier && strings.ToUpper(token.tokenValue.ident) == "LOOP"
 }

--- a/delimiter.go
+++ b/delimiter.go
@@ -55,7 +55,7 @@ func (d *Delimiter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
 		return nil, err
 	}
 	// 若匹配到自定义分隔符语法，则输出结果，否则匹配分隔符，输出结果
-	if matched || (d.matchedDelimiter(sqlText) && d.Scanner.lastScanOffset > 0) {
+	if matched || (d.matcheDelimiter(sqlText) && d.Scanner.lastScanOffset > 0) {
 		buff := bytes.Buffer{}
 		buff.WriteString(sqlText[:d.Scanner.lastScanOffset])
 		result := &sqlWithLineNumber{
@@ -123,7 +123,7 @@ func (d *Delimiter) isDelimiterCommand(token string) bool {
 	return strings.ToUpper(token) == DelimiterCommand
 }
 
-// 该函翻译自MySQL Client获取delimiter值的代码，参考：https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/client/mysql.cc#L4866
+// 该函数翻译自MySQL Client获取delimiter值的代码，参考：https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/client/mysql.cc#L4866
 func getDelimiter(line string) string {
 	ptr := 0
 	start := 0
@@ -173,7 +173,7 @@ func isSpace(c byte) bool {
 	由于scanner会把分隔符扫描为identifier或者其他单字符token类型，因此分为两种情况处理
 	注意，若将SQL关键字定义为分隔符，目前未处理该情况
 */
-func (d *Delimiter) matchedDelimiter(sql string) bool {
+func (d *Delimiter) matcheDelimiter(sql string) bool {
 
 	d.Scanner.reset(sql)
 	d.Scanner.lastScanOffset = 0

--- a/delimiter.go
+++ b/delimiter.go
@@ -30,9 +30,10 @@ func NewDelimiter() *Delimiter {
 
 func (d *Delimiter) ScanNextEndOfSql(sql string) (endOffset int, err error) {
 	d.Scanner.reset(sql)
+	d.Scanner.lastScanOffset = 0
 	var token *yySymType = &yySymType{}
 	var tokenType int
-
+	
 	for d.Scanner.lastScanOffset < len(sql) {
 		// 扫描下一个token
 		tokenType = d.Scanner.Lex(token)

--- a/delimiter.go
+++ b/delimiter.go
@@ -26,52 +26,6 @@ func NewDelimiter() *Delimiter {
 	return &Delimiter{}
 }
 
-/*
-该方法检测sql文本开头是否是自定义分隔符语法，若是匹配并更新分隔符:
-
- 1. 分隔符语法满足：delimiter str 或者 \d str
- 2. 参考链接：https://dev.mysql.com/doc/refman/5.7/en/mysql-commands.html
-*/
-func (s *splitter) matchAndSetCustomDelimiter(sql string) (bool, error) {
-	// 重置扫描器
-	s.scanner.Reset(sql)
-
-	var sqlAfterDelimiter string
-	token := s.scanner.Lex()
-	switch token.tokenType {
-	case BackSlash:
-		if s.delimiter.isSortDelimiterCommand(sql, s.scanner.Offset()) {
-			sqlAfterDelimiter = sql[s.scanner.Offset()+2:] // \d的长度是2字节
-			s.delimiter.startPos = s.scanner.Offset()
-			s.scanner.Seek(2)
-		}
-	case identifier:
-		if s.delimiter.isDelimiterCommand(token.tokenValue.ident) {
-			sqlAfterDelimiter = sql[s.scanner.Offset()+9:] //DELIMITER的长度是9字节
-			s.delimiter.startPos = s.scanner.Offset()
-			s.scanner.Seek(9)
-		}
-	default:
-		return false, nil
-	}
-	// 处理自定义分隔符
-	if sqlAfterDelimiter != "" {
-		end := strings.Index(sqlAfterDelimiter, "\n")
-		if end == -1 {
-			end = len(sqlAfterDelimiter)
-		}
-		newDelimiter := getDelimiter(sqlAfterDelimiter[:end])
-		if err := s.delimiter.setDelimiter(newDelimiter); err != nil {
-			return false, err
-		}
-		// 若识别到分隔符，则这一整行都为定义分隔符的sql，
-		// 例如 delimiter ;; xx 其中;;为分隔符，而xx不产生任何影响，但属于这条语句
-		s.scanner.Seek(end)
-		return true, nil
-	}
-	return false, nil
-}
-
 // \\d会被识别为三个token \ \ d 不能使用Lex，Lex可能会跳过空格和注释，因此这里使用字符串匹配
 func (d *Delimiter) isSortDelimiterCommand(sql string, index int) bool {
 	return index+2 < len(sql) && sql[index+1] == 'd'
@@ -124,47 +78,6 @@ func getDelimiter(line string) string {
 // 辅助函数,判断字符是否为空格
 func isSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
-}
-
-// ref:https://dev.mysql.com/doc/refman/8.4/en/flow-control-statements.html
-func (s *splitter) isTokenMatchDelimiter(token *Token) bool {
-	switch token.tokenType {
-	case s.delimiter.FirstTokenTypeOfDelimiter:
-		/*
-			在mysql client的语法中需要跳过注释以及分隔符处于引号中的情况，由于scanner.Lex会自动跳过注释，因此，仅需要判断分隔符处于引号中的情况。对于该方法，以分隔符的第一个token作为特征仅需匹配，可能会匹配到由引号括起的情况，存在stringLit和identifier两种token需要进一步判断：
-				1. 当匹配到identifier时，identifier有可能由反引号括起:
-					1. 若identifier没有反引号括起，则不需要判断是否跳过
-					2. 若identifier被反引号括起，匹配的字符串会带上反引号，能在匹配字符串时能够检查出是否需要跳过
-				2. 当匹配到stringLit时，stringLit一定是由单引号或双引号括起:
-					1. 当分隔符第一个token值与stringLit的token值不等，那么一定不是分隔符，则跳过
-					2. 当分隔符第一个token值与stringLit的token值相等， 如："'abc'd" '"abc"d'会因为字符串不匹配而跳过
-		*/
-		// 1. 当分隔符第一个token值与stringLit的token值不等，那么一定不是分隔符，则跳过
-		if token.tokenType == stringLit && token.tokenValue.ident != s.delimiter.FirstTokenValueOfDelimiter {
-			return false
-		}
-		// 2. 定位特征的第一个字符所处的位置
-		indexIntoken := strings.Index(token.tokenValue.ident, s.delimiter.FirstTokenValueOfDelimiter)
-		if indexIntoken == -1 {
-			return false
-		}
-		// 3. 字符串匹配
-		begin := s.scanner.Offset() + indexIntoken
-		end := begin + len(s.delimiter.DelimiterStr)
-		if begin < 0 || end > len(s.scanner.ScannedText()) {
-			return false
-		}
-		expected := s.scanner.ScannedText()[begin:end]
-		if expected != s.delimiter.DelimiterStr {
-			return false
-		}
-		s.scanner.Seek(end)
-		return true
-
-	case invalid:
-		s.scanner.handleInvalid()
-	}
-	return false
 }
 
 var ErrDelimiterCanNotExtractToken = errors.New("sorry, we cannot extract any token form the delimiter you provide, please change a delimiter")

--- a/delimiter.go
+++ b/delimiter.go
@@ -219,15 +219,16 @@ func (d *Delimiter) isTokenMatchDelimiter(tokenType int, token *yySymType) bool 
 					1. 当分隔符第一个token值与stringLit的token值不等，那么一定不是分隔符，则跳过
 					2. 当分隔符第一个token值与stringLit的token值相等， 如："'abc'd" '"abc"d'会因为字符串不匹配而跳过
 		*/
+		// 1. 当分隔符第一个token值与stringLit的token值不等，那么一定不是分隔符，则跳过
 		if tokenType == stringLit && token.ident != d.FirstTokenValueOfDelimiter {
 			return false
 		}
-		// 1. 定位特征的第一个字符所处的位置
+		// 2. 定位特征的第一个字符所处的位置
 		indexIntoken := strings.Index(token.ident, d.FirstTokenValueOfDelimiter)
 		if indexIntoken == -1 {
 			return false
 		}
-		// 2. 字符串匹配
+		// 3. 字符串匹配
 		begin := d.Scanner.lastScanOffset + indexIntoken
 		end := begin + len(d.DelimiterStr)
 		if begin < 0 || end > len(d.Scanner.r.s) {

--- a/delimiter.go
+++ b/delimiter.go
@@ -15,7 +15,6 @@ const (
 )
 
 type Delimiter struct {
-	Scanner                    *Scanner
 	FirstTokenTypeOfDelimiter  int
 	FirstTokenValueOfDelimiter string
 	DelimiterStr               string
@@ -24,9 +23,7 @@ type Delimiter struct {
 }
 
 func NewDelimiter() *Delimiter {
-	d := &Delimiter{}
-	d.Scanner = NewScanner("")
-	return d
+	return &Delimiter{}
 }
 
 /*
@@ -35,26 +32,24 @@ func NewDelimiter() *Delimiter {
  1. 分隔符语法满足：delimiter str 或者 \d str
  2. 参考链接：https://dev.mysql.com/doc/refman/5.7/en/mysql-commands.html
 */
-func (d *Delimiter) matchAndSetCustomDelimiter(sql string) (bool, error) {
+func (s *splitter) matchAndSetCustomDelimiter(sql string) (bool, error) {
 	// 重置扫描器
-	token := &yySymType{}
-	d.Scanner.reset(sql)
-	d.Scanner.lastScanOffset = 0
+	s.scanner.Reset(sql)
 
 	var sqlAfterDelimiter string
-
-	switch d.Scanner.Lex(token) {
+	token := s.scanner.Lex()
+	switch token.tokenType {
 	case BackSlash:
-		if d.isSortDelimiterCommand(sql) {
-			sqlAfterDelimiter = sql[d.Scanner.lastScanOffset+2:] // \d的长度是2字节
-			d.startPos = d.Scanner.lastScanOffset
-			d.Scanner.lastScanOffset += 2
+		if s.delimiter.isSortDelimiterCommand(sql, s.scanner.Offset()) {
+			sqlAfterDelimiter = sql[s.scanner.Offset()+2:] // \d的长度是2字节
+			s.delimiter.startPos = s.scanner.Offset()
+			s.scanner.Seek(2)
 		}
 	case identifier:
-		if d.isDelimiterCommand(token.ident) {
-			sqlAfterDelimiter = sql[d.Scanner.lastScanOffset+9:] //DELIMITER的长度是9字节
-			d.startPos = d.Scanner.lastScanOffset
-			d.Scanner.lastScanOffset += 9
+		if s.delimiter.isDelimiterCommand(token.tokenValue.ident) {
+			sqlAfterDelimiter = sql[s.scanner.Offset()+9:] //DELIMITER的长度是9字节
+			s.delimiter.startPos = s.scanner.Offset()
+			s.scanner.Seek(9)
 		}
 	default:
 		return false, nil
@@ -66,20 +61,20 @@ func (d *Delimiter) matchAndSetCustomDelimiter(sql string) (bool, error) {
 			end = len(sqlAfterDelimiter)
 		}
 		newDelimiter := getDelimiter(sqlAfterDelimiter[:end])
-		if err := d.setDelimiter(newDelimiter); err != nil {
+		if err := s.delimiter.setDelimiter(newDelimiter); err != nil {
 			return false, err
 		}
 		// 若识别到分隔符，则这一整行都为定义分隔符的sql，
 		// 例如 delimiter ;; xx 其中;;为分隔符，而xx不产生任何影响，但属于这条语句
-		d.Scanner.lastScanOffset += end
+		s.scanner.Seek(end)
 		return true, nil
 	}
 	return false, nil
 }
 
 // \\d会被识别为三个token \ \ d 不能使用Lex，Lex可能会跳过空格和注释，因此这里使用字符串匹配
-func (d *Delimiter) isSortDelimiterCommand(sql string) bool {
-	return d.Scanner.lastScanOffset+2 < len(sql) && sql[d.Scanner.lastScanOffset+1] == 'd'
+func (d *Delimiter) isSortDelimiterCommand(sql string, index int) bool {
+	return index+2 < len(sql) && sql[index+1] == 'd'
 }
 
 // DELIMITER会被识别为identifier，因此这里仅需识别其值是否相等
@@ -131,11 +126,10 @@ func isSpace(c byte) bool {
 	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }
 
-
 // ref:https://dev.mysql.com/doc/refman/8.4/en/flow-control-statements.html
-func (d *Delimiter) isTokenMatchDelimiter(tokenType int, token *yySymType) bool {
-	switch tokenType {
-	case d.FirstTokenTypeOfDelimiter:
+func (s *splitter) isTokenMatchDelimiter(token *Token) bool {
+	switch token.tokenType {
+	case s.delimiter.FirstTokenTypeOfDelimiter:
 		/*
 			在mysql client的语法中需要跳过注释以及分隔符处于引号中的情况，由于scanner.Lex会自动跳过注释，因此，仅需要判断分隔符处于引号中的情况。对于该方法，以分隔符的第一个token作为特征仅需匹配，可能会匹配到由引号括起的情况，存在stringLit和identifier两种token需要进一步判断：
 				1. 当匹配到identifier时，identifier有可能由反引号括起:
@@ -146,31 +140,29 @@ func (d *Delimiter) isTokenMatchDelimiter(tokenType int, token *yySymType) bool 
 					2. 当分隔符第一个token值与stringLit的token值相等， 如："'abc'd" '"abc"d'会因为字符串不匹配而跳过
 		*/
 		// 1. 当分隔符第一个token值与stringLit的token值不等，那么一定不是分隔符，则跳过
-		if tokenType == stringLit && token.ident != d.FirstTokenValueOfDelimiter {
+		if token.tokenType == stringLit && token.tokenValue.ident != s.delimiter.FirstTokenValueOfDelimiter {
 			return false
 		}
 		// 2. 定位特征的第一个字符所处的位置
-		indexIntoken := strings.Index(token.ident, d.FirstTokenValueOfDelimiter)
+		indexIntoken := strings.Index(token.tokenValue.ident, s.delimiter.FirstTokenValueOfDelimiter)
 		if indexIntoken == -1 {
 			return false
 		}
 		// 3. 字符串匹配
-		begin := d.Scanner.lastScanOffset + indexIntoken
-		end := begin + len(d.DelimiterStr)
-		if begin < 0 || end > len(d.Scanner.r.s) {
+		begin := s.scanner.Offset() + indexIntoken
+		end := begin + len(s.delimiter.DelimiterStr)
+		if begin < 0 || end > len(s.scanner.ScannedText()) {
 			return false
 		}
-		expected := d.Scanner.r.s[begin:end]
-		if expected != d.DelimiterStr {
+		expected := s.scanner.ScannedText()[begin:end]
+		if expected != s.delimiter.DelimiterStr {
 			return false
 		}
-		d.Scanner.lastScanOffset = end
+		s.scanner.Seek(end)
 		return true
 
 	case invalid:
-		if d.Scanner.lastScanOffset == d.Scanner.r.p.Offset {
-			d.Scanner.r.inc()
-		}
+		s.scanner.handleInvalid()
 	}
 	return false
 }
@@ -224,4 +216,10 @@ func isReservedKeyWord(input string) bool {
 	}
 	// 如果分隔符识别为一个关键字，但不知道是哪个关键字，则为identifier，此时就非保留字
 	return tokenType != identifier && tokenType > yyEOFCode && tokenType < yyDefault
+}
+
+func (d *Delimiter) reset() {
+	d.line = 0
+	d.startPos = 0
+	d.setDelimiter(DefaultDelimiterString)
 }

--- a/delimiter.go
+++ b/delimiter.go
@@ -1,0 +1,243 @@
+package parser
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+)
+
+const (
+	BackSlash              int    = '\\'
+	BackSlashString        string = "\\"
+	BlankSpace             string = " "
+	DefaultDelimiterString string = ";"
+	DelimiterCommand       string = "DELIMITER"
+	DelimiterCommandSort   string = `\d`
+)
+
+type Delimiter struct {
+	Scanner        *Scanner
+	DelimiterStr   string
+	DelimiterBytes []byte
+}
+
+func NewDelimiter() *Delimiter {
+	d := &Delimiter{}
+	d.setDelimiter(DefaultDelimiterString)
+	d.Scanner = NewScanner("")
+	return d
+}
+
+func (d *Delimiter) ScanNextEndOfSql(sql string) (endOffset int, err error) {
+	d.Scanner.reset(sql)
+	var token *yySymType = &yySymType{}
+	var tokenType int
+
+	for d.Scanner.lastScanOffset < len(sql) {
+		// 扫描下一个token
+		tokenType = d.Scanner.Lex(token)
+		// 当token无效且扫描偏移量未变时，增加偏移量
+		if tokenType == invalid && d.Scanner.lastScanOffset == d.Scanner.r.p.Offset {
+			d.Scanner.r.inc()
+			continue
+		}
+		if err := d.detectAndSetCustomDelimiter(token, tokenType); err != nil {
+			return 0, err
+		}
+		if d.matchedDelimiter(token, tokenType) {
+			return d.Scanner.lastScanOffset, nil
+		}
+	}
+
+	return d.Scanner.lastScanOffset, nil
+}
+
+/*
+该方法检测自定义分隔符语法并更新分隔符:
+
+ 1. 分隔符语法满足：delimiter str 或者 \d str
+ 2. 参考链接：https://dev.mysql.com/doc/refman/5.7/en/mysql-commands.html
+*/
+func (d *Delimiter) detectAndSetCustomDelimiter(token *yySymType, tokenType int) error {
+	switch tokenType {
+	case BackSlash:
+		// 如果token是反斜杠，尝试匹配简短分隔符命令，并设置自定义分隔符
+		if matched, customDelimiter := matchDelimiterCommandSort(d.Scanner.r.s); matched {
+			if err := d.setDelimiter(customDelimiter); err != nil {
+				return err
+			}
+		}
+	case identifier:
+		// 如果token是DELIMITER，尝试匹配常规分隔符命令，并设置自定义分隔符
+		if strings.ToUpper(token.ident) == DelimiterCommand {
+			if matched, customDelimiter := matchDelimiterCommand(d.Scanner.r.s); matched {
+				if err := d.setDelimiter(customDelimiter); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// 匹配分隔符定义语法 DELIMITER str
+func matchDelimiterCommand(input string) (isMached bool, delimiter string) {
+	/*
+		1. (?i) 表示无视大小写
+		2. \s* 匹配任意数量的空白字符(空格、制表符、换行符等)
+		3. DELIMITER 用于匹配字符串DELIMITER，即定义分隔符的常规语法
+		4. \x20+ 表示匹配1至多个空格
+		5. (\S+)：这是一个捕获组。\S匹配任意非空白字符，+表示匹配前面的模式一次或多次
+	*/
+	re := regexp.MustCompile(`(?i)\s*DELIMITER\x20+` + `((?:"(.*)"|'(.*)'|` + "`(.*)`" + `))`)
+	matches := re.FindStringSubmatch(input)
+	if len(matches) > 1 {
+		return true, matches[1]
+	}
+	re = regexp.MustCompile(`(?i)\s*DELIMITER\x20+(\S+)`)
+	matches = re.FindStringSubmatch(input)
+	if len(matches) > 1 {
+		return true, matches[1]
+	}
+	return false, ""
+}
+
+// 匹配分隔符定义语法 \d str
+func matchDelimiterCommandSort(input string) (isMached bool, delimiter string) {
+	/*
+		1. \s*：匹配任意数量的空白字符(空格、制表符、换行符等)
+		2. regexp.QuoteMeta("\\d") 用于匹配字符串\d，即定义分隔符的简短语法
+		3. \x20+ 表示匹配1至多个空格
+		4. (\S+)：这是一个捕获组。\S匹配任意非空白字符，+表示匹配前面的模式一次或多次
+	*/
+	re := regexp.MustCompile(`\s*` + regexp.QuoteMeta(DelimiterCommandSort) + `\x20+` + `((?:"(.*)"|'(.*)'|` + "`(.*)`" + `))`)
+	matches := re.FindStringSubmatch(input)
+	if len(matches) > 1 {
+		return true, matches[1]
+	}
+	re = regexp.MustCompile(`\s*` + regexp.QuoteMeta(DelimiterCommandSort) + `\x20+(\S+)`)
+	matches = re.FindStringSubmatch(input)
+	if len(matches) > 1 {
+		return true, matches[1]
+	}
+	return false, ""
+}
+
+var ErrDelimiterIsCommentStyle = errors.New("please do not use c-style comment as delimiter")
+var ErrDelimiterContainsBackslash = errors.New("DELIMITER cannot contain a backslash character")
+var ErrDelimiterContainsBlankSpace = errors.New("DELIMITER should not contain blank space")
+var ErrDelimiterMissing = errors.New("DELIMITER must be followed by a 'delimiter' character or string")
+var ErrDelimiterReservedKeyword = errors.New("delimiter should not use a reserved keyword")
+
+/*
+该方法设置分隔符，对分隔符的内容有一定的限制：
+
+ 1. 不允许分隔符内部包含反斜杠
+ 2. 不允许分隔符为空字符串
+ 3. 不允许分隔符为C语言风格的注释，因为scanner在扫描token的时候会跳过注释内容，处理情况复杂
+ 4. 不允许分隔符为mysql的保留字，因为这样会被scanner扫描为其他类型的token，从而绕过判断分隔符的逻辑
+
+注：其中1和2与MySQL客户端对分隔符内容一致，错误内容参考MySQL客户端源码中的com_delimiter函数
+https://github.com/mysql/mysql-server/blob/824e2b4064053f7daf17d7f3f84b7a3ed92e5fb4/client/mysql.cc#L4621
+*/
+func (d *Delimiter) setDelimiter(delimiter string) (err error) {
+
+	if isCommentLikeC(delimiter) {
+		return ErrDelimiterIsCommentStyle
+	}
+	if strings.Contains(delimiter, BackSlashString) {
+		return ErrDelimiterContainsBackslash
+	}
+	if strings.Contains(delimiter, BlankSpace) {
+		return ErrDelimiterContainsBlankSpace
+	}
+	if delimiter = removeOuterQuotes(delimiter); delimiter == "" {
+		return ErrDelimiterMissing
+	}
+	if isReservedKeyWord(delimiter) {
+		return ErrDelimiterReservedKeyword
+	}
+
+	d.DelimiterStr = delimiter
+	d.DelimiterBytes = []byte(delimiter)
+	return nil
+}
+
+func isCommentLikeC(str string) bool {
+	re := regexp.MustCompile(`^\/\*[\s\S]*?\*\/$`)
+	return re.MatchString(str)
+}
+
+// 定义分隔符的时候如果使用引号将分隔符进行包裹，则需要自动去掉一层引号
+func removeOuterQuotes(s string) string {
+	// 匹配单引号
+	singleQuoteRegex := regexp.MustCompile(`^'(.*)'$`)
+	matches := singleQuoteRegex.FindStringSubmatch(s)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	// 匹配双引号
+	doubleQuoteRegex := regexp.MustCompile(`^"(.*)"$`)
+	matches = doubleQuoteRegex.FindStringSubmatch(s)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	// 匹配反引号
+	backTickRegex := regexp.MustCompile("`(.*)`")
+	matches = backTickRegex.FindStringSubmatch(s)
+	if len(matches) > 1 {
+		return matches[1]
+	}
+	return s
+}
+
+func isReservedKeyWord(input string) bool {
+	s := NewScanner(input)
+	var token *yySymType = &yySymType{}
+	tokenType := s.Lex(token)
+	if len(token.ident) < len(input) {
+		// 如果分隔符无法识别为一个token，则一定不是关键字
+		return false
+	}
+	// 如果分隔符识别为一个关键字，但不知道是哪个关键字，则为identifier，此时就非保留字
+	return tokenType != identifier && tokenType > yyEOFCode && tokenType < yyDefault
+}
+
+func (d *Delimiter) delimiter() string {
+	return d.DelimiterStr
+}
+
+/*
+该方法检测分隔符：
+
+	由于scanner会把分隔符扫描为identifier或者其他单字符token类型，因此分为两种情况处理
+	注意，若将SQL关键字定义为分隔符，目前未处理该情况
+*/
+func (d *Delimiter) matchedDelimiter(token *yySymType, tokenType int) bool {
+	switch tokenType {
+	case identifier:
+		// 当token是当前分隔符时，更新扫描偏移量并返回true
+		if strings.Contains(token.ident, d.delimiter()) {
+			d.Scanner.lastScanOffset += len(d.delimiter()) + strings.Index(token.ident, d.DelimiterStr)
+			return true
+		}
+	case d.firstAsciiValueOfDelimiter():
+		// 检查当前扫描位置是否匹配当前分隔符的第一个字符
+		expectedEnd := d.Scanner.lastScanOffset + len(d.delimiter())
+		if expectedEnd >= len(d.Scanner.r.s) {
+			return false
+		}
+		if d.Scanner.r.s[d.Scanner.lastScanOffset:expectedEnd] == d.delimiter() {
+			d.Scanner.lastScanOffset = expectedEnd
+			return true
+		}
+	}
+	return false
+}
+
+func (d *Delimiter) firstAsciiValueOfDelimiter() int {
+	if len(d.DelimiterBytes) > 0 {
+		return int(d.DelimiterBytes[0])
+	}
+	return -1
+}

--- a/delimiter.go
+++ b/delimiter.go
@@ -3,7 +3,6 @@ package parser
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -74,7 +73,10 @@ func (d *Delimiter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
 		d.line += d.Scanner.r.pos().Line - 1 // 表示的是该SQL中有多少换行
 		return result, nil
 	}
-	return nil, fmt.Errorf("cannot reslove sql: %v", sql)
+	return &sqlWithLineNumber{
+		sql:  strings.TrimSpace(sqlText),
+		line: d.line + strings.Count(sqlText[:d.startPos], "\n") + 1,
+	}, nil
 }
 
 /*
@@ -205,7 +207,6 @@ func (d *Delimiter) matcheDelimiter(sql string) bool {
 	return false
 }
 
-
 func (d *Delimiter) isTokenMatchDelimiter(tokenType int, token *yySymType) bool {
 	switch tokenType {
 	case identifier:
@@ -233,7 +234,6 @@ const (
 	DoubleQuotes byte = '"'
 	BackQuotes   byte = '`'
 )
-
 
 func (d *Delimiter) isIdentifierContainDelimiter(token *yySymType) bool {
 	if !strings.Contains(token.ident, d.delimiter()) {

--- a/delimiter.go
+++ b/delimiter.go
@@ -249,12 +249,6 @@ func (d *Delimiter) isTokenMatchDelimiter(tokenType int, token *yySymType) bool 
 	return false
 }
 
-const (
-	Quotes       byte = '\''
-	DoubleQuotes byte = '"'
-	BackQuotes   byte = '`'
-)
-
 var ErrDelimiterCanNotExtractToken = errors.New("sorry, we cannot extract any token form the delimiter you provide, please change a delimiter")
 var ErrDelimiterContainsBackslash = errors.New("DELIMITER cannot contain a backslash character")
 var ErrDelimiterContainsBlankSpace = errors.New("DELIMITER should not contain blank space")

--- a/parser_for_splitter.go
+++ b/parser_for_splitter.go
@@ -1,0 +1,22 @@
+package parser
+
+import "github.com/pingcap/parser/ast"
+
+type ParserForSplitter struct {
+	parser *Parser
+}
+
+func NewParserForSplitter() *ParserForSplitter {
+	return &ParserForSplitter{
+		parser: New(),
+	}
+}
+
+func (p *ParserForSplitter) Parse(sql string) (stmt []ast.StmtNode, err error) {
+	stmt, _, err = p.parser.Parse(sql, "", "")
+	return
+}
+
+func (p *ParserForSplitter) Result() []ast.StmtNode {
+	return p.parser.result
+}

--- a/scanner.go
+++ b/scanner.go
@@ -19,8 +19,8 @@ func (s *ScannerForSplitter) Offset() int {
 	return s.scanner.lastScanOffset
 }
 
-func (s *ScannerForSplitter) Seek(offset int) {
-	s.scanner.lastScanOffset += offset
+func (s *ScannerForSplitter) SetCursor(offset int) {
+	s.scanner.lastScanOffset = offset
 }
 
 type Token struct {

--- a/scanner.go
+++ b/scanner.go
@@ -23,9 +23,32 @@ func (s *ScannerForSplitter) SetCursor(offset int) {
 	s.scanner.lastScanOffset = offset
 }
 
+const (
+	Identifier int = identifier
+	YyEOFCode  int = yyEOFCode
+	YyDefault  int = yyDefault
+	IfKwd      int = ifKwd
+	CaseKwd    int = caseKwd
+	Repeat     int = repeat
+	Begin      int = begin
+	End        int = end
+	StringLit  int = stringLit
+	Invalid    int = invalid
+)
+
+type TokenValue yySymType
+
 type Token struct {
 	tokenType  int
 	tokenValue *yySymType
+}
+
+func (t Token) Ident() string {
+	return t.tokenValue.ident
+}
+
+func (t Token) TokenType() int {
+	return t.tokenType
 }
 
 func (s *ScannerForSplitter) Lex() *Token {
@@ -45,7 +68,7 @@ func (s *ScannerForSplitter) ScannedText() string {
 	return s.scanner.r.s
 }
 
-func (s *ScannerForSplitter) handleInvalid() {
+func (s *ScannerForSplitter) HandleInvalid() {
 	if s.scanner.lastScanOffset == s.scanner.r.p.Offset {
 		s.scanner.r.inc()
 	}

--- a/scanner.go
+++ b/scanner.go
@@ -1,0 +1,52 @@
+package parser
+
+type ScannerForSplitter struct {
+	scanner *Scanner
+}
+
+func NewScannerForSplitter() *ScannerForSplitter {
+	return &ScannerForSplitter{
+		scanner: NewScanner(""),
+	}
+}
+
+func (s *ScannerForSplitter) Reset(sql string) {
+	s.scanner.reset(sql)
+	s.scanner.lastScanOffset = 0
+}
+
+func (s *ScannerForSplitter) Offset() int {
+	return s.scanner.lastScanOffset
+}
+
+func (s *ScannerForSplitter) Seek(offset int) {
+	s.scanner.lastScanOffset += offset
+}
+
+type Token struct {
+	tokenType  int
+	tokenValue *yySymType
+}
+
+func (s *ScannerForSplitter) Lex() *Token {
+	tokenValue := &yySymType{}
+	tokenType := s.scanner.Lex(tokenValue)
+	return &Token{
+		tokenType:  tokenType,
+		tokenValue: tokenValue,
+	}
+}
+
+func (s *ScannerForSplitter) ScannedLines() int {
+	return s.scanner.r.pos().Line - 1
+}
+
+func (s *ScannerForSplitter) ScannedText() string {
+	return s.scanner.r.s
+}
+
+func (s *ScannerForSplitter) handleInvalid() {
+	if s.scanner.lastScanOffset == s.scanner.r.p.Offset {
+		s.scanner.r.inc()
+	}
+}

--- a/splitter.go
+++ b/splitter.go
@@ -84,7 +84,7 @@ func (s *splitter) splitSqlText(sqlText string) (results []*sqlWithLineNumber, e
 	return results, nil
 }
 
-func (s *splitter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
+func (s *splitter)  getNextSql(sqlText string) (*sqlWithLineNumber, error) {
 	matcheDelimiterCommand, err := s.matchAndSetCustomDelimiter(sqlText)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (s *splitter) isTokenMatchDelimiter(token *Token) bool {
 		return true
 
 	case invalid:
-		s.scanner.handleInvalid()
+		s.scanner.HandleInvalid()
 	}
 	return false
 }

--- a/splitter.go
+++ b/splitter.go
@@ -10,17 +10,22 @@ import (
 type splitter struct {
 	parser    *Parser
 	delimiter *Delimiter
+	blocker   *Blocker
+	scanner   *ScannerForSplitter
 }
 
 func NewSplitter() *splitter {
 	return &splitter{
 		parser:    New(),
 		delimiter: NewDelimiter(),
+		blocker:   NewBlocker(),
+		scanner:   NewScannerForSplitter(),
 	}
 }
 
 func (s *splitter) ParseSqlText(sqlText string) ([]ast.StmtNode, error) {
-	results, err := s.SplitSqlText(sqlText)
+	s.delimiter.reset()
+	results, err := s.splitSqlText(sqlText)
 	if err != nil {
 		return nil, err
 	}
@@ -28,11 +33,11 @@ func (s *splitter) ParseSqlText(sqlText string) ([]ast.StmtNode, error) {
 }
 
 func (s *splitter) processToExecutableNodes(results []*sqlWithLineNumber) []ast.StmtNode {
-	s.delimiter.setDelimiter(DefaultDelimiterString)
+	s.delimiter.reset()
 
 	var executableNodes []ast.StmtNode
 	for _, result := range results {
-		if matched, _ := s.delimiter.matchAndSetCustomDelimiter(result.sql); matched {
+		if matched, _ := s.matchAndSetCustomDelimiter(result.sql); matched {
 			continue
 		}
 		trimmedSQL := strings.TrimSuffix(result.sql, s.delimiter.DelimiterStr)
@@ -63,13 +68,6 @@ type sqlWithLineNumber struct {
 	line int
 }
 
-func (s *splitter) SplitSqlText(sqlText string) (results []*sqlWithLineNumber, err error) {
-	s.delimiter.line = 0
-	s.delimiter.startPos = 0
-	s.delimiter.setDelimiter(DefaultDelimiterString)
-	return s.splitSqlText(sqlText)
-}
-
 func (s *splitter) splitSqlText(sqlText string) (results []*sqlWithLineNumber, err error) {
 	result, err := s.getNextSql(sqlText)
 	if err != nil {
@@ -77,28 +75,28 @@ func (s *splitter) splitSqlText(sqlText string) (results []*sqlWithLineNumber, e
 	}
 	results = append(results, result)
 	// 递归切分剩余SQL
-	if s.delimiter.Scanner.lastScanOffset < len(sqlText) {
-		subResults, _ := s.splitSqlText(sqlText[s.delimiter.Scanner.lastScanOffset:])
+	if s.scanner.Offset() < len(sqlText) {
+		subResults, _ := s.splitSqlText(sqlText[s.scanner.Offset():])
 		results = append(results, subResults...)
 	}
 	return results, nil
 }
 
 func (s *splitter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
-	matcheDelimiterCommand, err := s.delimiter.matchAndSetCustomDelimiter(sqlText)
+	matcheDelimiterCommand, err := s.matchAndSetCustomDelimiter(sqlText)
 	if err != nil {
 		return nil, err
 	}
 	// 若匹配到自定义分隔符语法，则输出结果，否则匹配分隔符，输出结果
 	if matcheDelimiterCommand || s.matcheSql(sqlText) {
 		buff := bytes.Buffer{}
-		buff.WriteString(sqlText[:s.delimiter.Scanner.lastScanOffset])
+		buff.WriteString(sqlText[:s.scanner.Offset()])
 		lineBeforeStart := strings.Count(sqlText[:s.delimiter.startPos], "\n")
 		result := &sqlWithLineNumber{
 			sql:  strings.TrimSpace(buff.String()),
 			line: s.delimiter.line + lineBeforeStart + 1,
 		}
-		s.delimiter.line += s.delimiter.Scanner.r.pos().Line - 1 // 表示的是该SQL中有多少换行
+		s.delimiter.line += s.scanner.ScannedLines() // pos().Line-1表示的是该SQL中有多少换行
 		return result, nil
 	}
 	return &sqlWithLineNumber{
@@ -108,43 +106,42 @@ func (s *splitter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
 }
 
 func (s *splitter) matcheSql(sql string) bool {
-	s.delimiter.Scanner.reset(sql)
-	s.delimiter.Scanner.lastScanOffset = 0
-	token := &yySymType{}
+	s.scanner.Reset(sql)
+	token := &Token{}
 	var isFirstToken bool = true
 
-	for s.delimiter.Scanner.lastScanOffset < len(sql) {
-		tokenType := s.delimiter.Scanner.Lex(token)
+	for s.scanner.Offset() < len(sql) {
+		token = s.scanner.Lex()
 		if isFirstToken {
-			s.delimiter.startPos = s.delimiter.Scanner.lastScanOffset
+			s.delimiter.startPos = s.scanner.Offset()
 			isFirstToken = false
 		}
-		tokenType, token = s.skipBeginEndBlock(tokenType, token)
-		if s.delimiter.isTokenMatchDelimiter(tokenType, token) {
+		token = s.skipBeginEndBlock(token)
+		if s.isTokenMatchDelimiter(token) {
 			return true
 		}
 	}
 	return false
 }
 
-func (s *splitter) skipBeginEndBlock(tokenType int, token *yySymType) (int, *yySymType) {
+func (s *splitter) skipBeginEndBlock(token *Token) *Token {
 	var blockStack []Block
-	if tokenType == begin {
+	if token.tokenType == begin {
 		blockStack = append(blockStack, BeginEndBlock{})
 	}
 	for len(blockStack) > 0 {
-		tokenType = s.delimiter.Scanner.Lex(token)
+		token = s.scanner.Lex()
 		for _, block := range allBlocks {
-			if block.MatchBegin(tokenType, token) {
+			if block.MatchBegin(token) {
 				blockStack = append(blockStack, block)
 				break
 			}
 		}
 		// 如果匹配到END，则需要判断END后的token是否匹配当前的Block
-		if tokenType == end {
+		if token.tokenType == end {
 			currentBlock := blockStack[len(blockStack)-1]
-			tokenType = s.delimiter.Scanner.Lex(token)
-			if currentBlock.MatchEnd(tokenType, token) {
+			token = s.scanner.Lex()
+			if currentBlock.MatchEnd(token) {
 				blockStack = blockStack[:len(blockStack)-1]
 			}
 		}
@@ -152,5 +149,5 @@ func (s *splitter) skipBeginEndBlock(tokenType int, token *yySymType) (int, *yyS
 			break
 		}
 	}
-	return tokenType, token
+	return token
 }

--- a/splitter.go
+++ b/splitter.go
@@ -18,47 +18,50 @@ func NewSplitter() *splitter {
 	}
 }
 
-func (s *splitter) ParseSqlText(sqlText string) (allNodes []ast.StmtNode, err error) {
+func (s *splitter) ParseSqlText(sqlText string) ([]ast.StmtNode, error) {
+
 	results, err := s.delimiter.SplitSqlText(sqlText)
 	if err != nil {
 		return nil, err
 	}
+
+	var allNodes []ast.StmtNode
 	for _, result := range results {
 		s.parser.Parse(result.sql, "", "")
-
 		if len(s.parser.result) == 1 {
-			s.parser.result[0].SetStartLine(result.line)
-			allNodes = append(allNodes, s.parser.result[0])
+			// 若结果集长度为1，则为单条且可解析的SQL
+			stmt := s.parser.result[0]
+			stmt.SetStartLine(result.line)
+			allNodes = append(allNodes, stmt)
 		} else {
+			// 若结果集长度大于1，则为多条合并的SQL
+			// 若结果集长度为0，则不可解析的SQL
 			unParsedStmt := &ast.UnparsedStmt{}
 			unParsedStmt.SetStartLine(result.line)
 			unParsedStmt.SetText(result.sql)
 			allNodes = append(allNodes, unParsedStmt)
 		}
 	}
+
 	return allNodes, nil
 }
 
-func (s *splitter) ProcessToExecutableNodes(results []ast.StmtNode) (executableNodes []ast.StmtNode) {
-	var currentDelimiter string = DefaultDelimiterString
-	var sql string
+func (s *splitter) ProcessToExecutableNodes(results []ast.StmtNode) []ast.StmtNode {
+
+	var executableNodes []ast.StmtNode
 	for _, node := range results {
 		if stmt, isUnparsed := node.(*ast.UnparsedStmt); isUnparsed {
-			if matched, delimiter := matchDelimiterCommand(stmt.Text()); matched {
-				currentDelimiter = delimiter
-				continue
-			}
-			if matched, delimiter := matchDelimiterCommandSort(stmt.Text()); matched {
-				currentDelimiter = delimiter
+			if matched, _ := s.delimiter.matchAndSetCustomDelimiter(stmt.Text()); matched {
 				continue
 			}
 		}
-		sql = strings.TrimSuffix(node.Text(), currentDelimiter)
-		if sql == "" {
+		trimmedSQL := strings.TrimSuffix(node.Text(), s.delimiter.delimiter())
+		if trimmedSQL == "" {
 			continue
 		}
-		node.SetText(sql)
+		node.SetText(trimmedSQL)
 		executableNodes = append(executableNodes, node)
 	}
+
 	return executableNodes
 }

--- a/splitter.go
+++ b/splitter.go
@@ -202,7 +202,6 @@ func (s *splitter) isTokenMatchDelimiter(token *Token) bool {
 func (s *splitter) matchAndSetCustomDelimiter(sql string) (bool, error) {
 	// 重置扫描器
 	s.scanner.Reset(sql)
-	// TODO sql a
 	var sqlAfterDelimiter string
 	token := s.scanner.Lex()
 	switch token.tokenType {
@@ -224,7 +223,7 @@ func (s *splitter) matchAndSetCustomDelimiter(sql string) (bool, error) {
 	// 处理自定义分隔符
 	if sqlAfterDelimiter != "" {
 		restOfThisLine := strings.Index(sqlAfterDelimiter, "\n")
-		if end == -1 {
+		if restOfThisLine == -1 {
 			restOfThisLine = len(sqlAfterDelimiter)
 		}
 		newDelimiter := getDelimiter(sqlAfterDelimiter[:restOfThisLine])

--- a/splitter.go
+++ b/splitter.go
@@ -59,7 +59,7 @@ func (s *splitter) ProcessToExecutableNodes(results []ast.StmtNode) []ast.StmtNo
 		if trimmedSQL == "" {
 			continue
 		}
-		node.SetText(trimmedSQL)
+		node.SetText(trimmedSQL + ";")
 		executableNodes = append(executableNodes, node)
 	}
 

--- a/splitter.go
+++ b/splitter.go
@@ -19,49 +19,40 @@ func NewSplitter() *splitter {
 }
 
 func (s *splitter) ParseSqlText(sqlText string) ([]ast.StmtNode, error) {
-
 	results, err := s.delimiter.SplitSqlText(sqlText)
 	if err != nil {
 		return nil, err
 	}
+	return s.processToExecutableNodes(results), nil
+}
 
-	var allNodes []ast.StmtNode
+func (s *splitter) processToExecutableNodes(results []*sqlWithLineNumber) []ast.StmtNode {
+	s.delimiter.setDelimiter(DefaultDelimiterString)
+
+	var executableNodes []ast.StmtNode
 	for _, result := range results {
+		if matched, _ := s.delimiter.matchAndSetCustomDelimiter(result.sql); matched {
+			continue
+		}
+		trimmedSQL := strings.TrimSuffix(result.sql, s.delimiter.delimiter())
+		if trimmedSQL == "" {
+			continue
+		}
+		result.sql = trimmedSQL + ";"
 		s.parser.Parse(result.sql, "", "")
 		if len(s.parser.result) == 1 {
 			// 若结果集长度为1，则为单条且可解析的SQL
 			stmt := s.parser.result[0]
 			stmt.SetStartLine(result.line)
-			allNodes = append(allNodes, stmt)
+			executableNodes = append(executableNodes, stmt)
 		} else {
 			// 若结果集长度大于1，则为多条合并的SQL
 			// 若结果集长度为0，则不可解析的SQL
 			unParsedStmt := &ast.UnparsedStmt{}
 			unParsedStmt.SetStartLine(result.line)
 			unParsedStmt.SetText(result.sql)
-			allNodes = append(allNodes, unParsedStmt)
+			executableNodes = append(executableNodes, unParsedStmt)
 		}
 	}
-
-	return allNodes, nil
-}
-
-func (s *splitter) ProcessToExecutableNodes(results []ast.StmtNode) []ast.StmtNode {
-
-	var executableNodes []ast.StmtNode
-	for _, node := range results {
-		if stmt, isUnparsed := node.(*ast.UnparsedStmt); isUnparsed {
-			if matched, _ := s.delimiter.matchAndSetCustomDelimiter(stmt.Text()); matched {
-				continue
-			}
-		}
-		trimmedSQL := strings.TrimSuffix(node.Text(), s.delimiter.delimiter())
-		if trimmedSQL == "" {
-			continue
-		}
-		node.SetText(trimmedSQL + ";")
-		executableNodes = append(executableNodes, node)
-	}
-
 	return executableNodes
 }

--- a/splitter.go
+++ b/splitter.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"bytes"
 	"strings"
 
 	"github.com/pingcap/parser/ast"
@@ -19,7 +20,7 @@ func NewSplitter() *splitter {
 }
 
 func (s *splitter) ParseSqlText(sqlText string) ([]ast.StmtNode, error) {
-	results, err := s.delimiter.SplitSqlText(sqlText)
+	results, err := s.SplitSqlText(sqlText)
 	if err != nil {
 		return nil, err
 	}
@@ -55,4 +56,103 @@ func (s *splitter) processToExecutableNodes(results []*sqlWithLineNumber) []ast.
 		}
 	}
 	return executableNodes
+}
+
+type sqlWithLineNumber struct {
+	sql  string
+	line int
+}
+
+func (s *splitter) SplitSqlText(sqlText string) (results []*sqlWithLineNumber, err error) {
+	s.delimiter.line = 0
+	s.delimiter.startPos = 0
+	s.delimiter.setDelimiter(DefaultDelimiterString)
+	return s.splitSqlText(sqlText)
+}
+
+func (s *splitter) splitSqlText(sqlText string) (results []*sqlWithLineNumber, err error) {
+	result, err := s.getNextSql(sqlText)
+	if err != nil {
+		return nil, err
+	}
+	results = append(results, result)
+	// 递归切分剩余SQL
+	if s.delimiter.Scanner.lastScanOffset < len(sqlText) {
+		subResults, _ := s.splitSqlText(sqlText[s.delimiter.Scanner.lastScanOffset:])
+		results = append(results, subResults...)
+	}
+	return results, nil
+}
+
+func (s *splitter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
+	matcheDelimiterCommand, err := s.delimiter.matchAndSetCustomDelimiter(sqlText)
+	if err != nil {
+		return nil, err
+	}
+	// 若匹配到自定义分隔符语法，则输出结果，否则匹配分隔符，输出结果
+	if matcheDelimiterCommand || s.matcheSql(sqlText) {
+		buff := bytes.Buffer{}
+		buff.WriteString(sqlText[:s.delimiter.Scanner.lastScanOffset])
+		lineBeforeStart := strings.Count(sqlText[:s.delimiter.startPos], "\n")
+		result := &sqlWithLineNumber{
+			sql:  strings.TrimSpace(buff.String()),
+			line: s.delimiter.line + lineBeforeStart + 1,
+		}
+		s.delimiter.line += s.delimiter.Scanner.r.pos().Line - 1 // 表示的是该SQL中有多少换行
+		return result, nil
+	}
+	return &sqlWithLineNumber{
+		sql:  strings.TrimSpace(sqlText),
+		line: s.delimiter.line + strings.Count(sqlText[:s.delimiter.startPos], "\n") + 1,
+	}, nil
+}
+
+func (s *splitter) matcheSql(sql string) bool {
+	s.delimiter.Scanner.reset(sql)
+	s.delimiter.Scanner.lastScanOffset = 0
+	token := &yySymType{}
+	var isFirstToken bool = true
+
+	for s.delimiter.Scanner.lastScanOffset < len(sql) {
+		tokenType := s.delimiter.Scanner.Lex(token)
+		if isFirstToken {
+			s.delimiter.startPos = s.delimiter.Scanner.lastScanOffset
+			isFirstToken = false
+		}
+		tokenType, token = s.tarpInBlock(tokenType, token)
+		if s.delimiter.isTokenMatchDelimiter(tokenType, token) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *splitter) tarpInBlock(tokenType int, token *yySymType) (int, *yySymType) {
+	var needEndCount uint
+	if tokenType == begin {
+		needEndCount++
+	}
+	for needEndCount > 0 {
+		tokenType = s.delimiter.Scanner.Lex(token)
+		if tokenType == begin {
+			needEndCount++
+		}
+		if tokenType == end {
+			tokenType = s.delimiter.Scanner.Lex(token)
+			if tokenType == ifKwd || tokenType == caseKwd || tokenType == repeat {
+				continue
+			}
+			if tokenType == identifier {
+				if strings.ToUpper(token.ident) == "WHILE" {
+					continue
+				}
+
+				if strings.ToUpper(token.ident) == "LOOP" {
+					continue
+				}
+			}
+			needEndCount--
+		}
+	}
+	return tokenType, token
 }

--- a/splitter.go
+++ b/splitter.go
@@ -34,7 +34,7 @@ func (s *splitter) processToExecutableNodes(results []*sqlWithLineNumber) []ast.
 		if matched, _ := s.delimiter.matchAndSetCustomDelimiter(result.sql); matched {
 			continue
 		}
-		trimmedSQL := strings.TrimSuffix(result.sql, s.delimiter.delimiter())
+		trimmedSQL := strings.TrimSuffix(result.sql, s.delimiter.DelimiterStr)
 		if trimmedSQL == "" {
 			continue
 		}

--- a/splitter.go
+++ b/splitter.go
@@ -1,8 +1,6 @@
 package parser
 
 import (
-	"bytes"
-	"fmt"
 	"strings"
 
 	"github.com/pingcap/parser/ast"
@@ -20,69 +18,31 @@ func NewSplitter() *splitter {
 	}
 }
 
-func (s *splitter) SplitSqlText(sql, charset, collation string) (allNodes []ast.StmtNode, warns []error, err error) {
-	// 先使用parser尝试解析能解析的SQL
-	var stmtNodes []ast.StmtNode
-	stmtNodes, warns, err = s.resloveSqlsByParser(sql, charset, collation)
-	allNodes = append(allNodes, stmtNodes...)
-	if err == nil {
-		return allNodes, warns, nil
-	}
-	// 若未解析出任何SQL，则需要重置起始位置
-	if len(stmtNodes) == 0 {
-		s.parser.lexer.stmtStartPos = 0
-	}
-	// 根据parser的解析结果，使用未被解析的部分，解析出一条不支持解析的SQL
-	var unParsedNode ast.StmtNode
-	unParsedNode, err = s.resolveSqlsByDelimiter(sql[s.parser.lexer.stmtStartPos:])
-	if err != nil {
-		return allNodes, warns, err
-	}
-	allNodes = append(allNodes, unParsedNode)
-	// 递归切分剩余SQL
-	if s.parser.lexer.stmtStartPos < len(sql) {
-		nodes, _, _ := s.SplitSqlText(sql[s.parser.lexer.stmtStartPos:], charset, collation)
-		allNodes = append(allNodes, nodes...)
-	}
-	return allNodes, warns, nil
-}
-
-func (s *splitter) resloveSqlsByParser(sql, charset, collation string) (stmtNodes []ast.StmtNode, warns []error, err error) {
-	_, warns, err = s.parser.Parse(sql, charset, collation)
-	parseResults := s.parser.result
-	s.parser.updateStartLineWithOffset(parseResults)
-	if len(parseResults) > 0 {
-		for _, stmtNode := range parseResults {
-			ast.SetFlag(stmtNode)
-		}
-		stmtNodes = append(stmtNodes, parseResults...)
-	}
-	return stmtNodes, warns, err
-}
-
-func (s *splitter) resolveSqlsByDelimiter(sql string) (stmtNode ast.StmtNode, err error) {
-	endOffset, err := s.delimiter.ScanNextEndOfSql(sql)
+func (s *splitter) ParseSqlText(sqlText string) (allNodes []ast.StmtNode, err error) {
+	results, err := s.delimiter.SplitSqlText(sqlText)
 	if err != nil {
 		return nil, err
 	}
-	unparsedStmtBuf := bytes.Buffer{}
-	unparsedStmtBuf.WriteString(sql[:endOffset])
-	unparsedSql := unparsedStmtBuf.String()
-	unparsedSql = strings.TrimSpace(unparsedSql)
-	if len(unparsedSql) > 0 {
-		unParsedStmt := &ast.UnparsedStmt{}
-		unParsedStmt.SetStartLine(s.parser.startLineOffset)
-		unParsedStmt.SetText(unparsedSql)
-		s.parser.lexer.stmtStartPos += endOffset
-		return unParsedStmt, nil
+	for _, result := range results {
+		s.parser.Parse(result.sql, "", "")
+
+		if len(s.parser.result) == 1 {
+			s.parser.result[0].SetStartLine(result.line)
+			allNodes = append(allNodes, s.parser.result[0])
+		} else {
+			unParsedStmt := &ast.UnparsedStmt{}
+			unParsedStmt.SetStartLine(result.line)
+			unParsedStmt.SetText(result.sql)
+			allNodes = append(allNodes, unParsedStmt)
+		}
 	}
-	return nil, fmt.Errorf("cannot reslove unparsed SQL")
+	return allNodes, nil
 }
 
-func (s *splitter) ProcessToExecutableNodes(allNodes []ast.StmtNode) (executableNodes []ast.StmtNode) {
+func (s *splitter) ProcessToExecutableNodes(results []ast.StmtNode) (executableNodes []ast.StmtNode) {
 	var currentDelimiter string = DefaultDelimiterString
 	var sql string
-	for _, node := range allNodes {
+	for _, node := range results {
 		if stmt, isUnparsed := node.(*ast.UnparsedStmt); isUnparsed {
 			if matched, delimiter := matchDelimiterCommand(stmt.Text()); matched {
 				currentDelimiter = delimiter

--- a/splitter.go
+++ b/splitter.go
@@ -73,7 +73,9 @@ func (s *splitter) splitSqlText(sqlText string) (results []*sqlWithLineNumber, e
 	if err != nil {
 		return nil, err
 	}
-	results = append(results, result)
+	if result != nil{
+		results = append(results, result)
+	}
 	// 递归切分剩余SQL
 	if s.scanner.Offset() < len(sqlText) {
 		subResults, _ := s.splitSqlText(sqlText[s.scanner.Offset():])
@@ -99,8 +101,12 @@ func (s *splitter) getNextSql(sqlText string) (*sqlWithLineNumber, error) {
 		s.delimiter.line += s.scanner.ScannedLines() // pos().Line-1表示的是该SQL中有多少换行
 		return result, nil
 	}
+	restOfSql := strings.TrimSpace(sqlText)
+	if restOfSql == "" {
+		return nil, nil
+	}
 	return &sqlWithLineNumber{
-		sql:  strings.TrimSpace(sqlText),
+		sql:  restOfSql,
 		line: s.delimiter.line + strings.Count(sqlText[:s.delimiter.startPos], "\n") + 1,
 	}, nil
 }

--- a/splitter.go
+++ b/splitter.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/pingcap/parser/ast"
+)
+
+type splitter struct {
+	parser    *Parser
+	delimiter *Delimiter
+}
+
+func NewSplitter() *splitter {
+	return &splitter{
+		parser:    New(),
+		delimiter: NewDelimiter(),
+	}
+}
+
+func (s *splitter) SplitSqlText(sql, charset, collation string) (allNodes []ast.StmtNode, warns []error, err error) {
+	// 先使用parser尝试解析能解析的SQL
+	var stmtNodes []ast.StmtNode
+	stmtNodes, warns, err = s.resloveSqlsByParser(sql, charset, collation)
+	allNodes = append(allNodes, stmtNodes...)
+	if err == nil {
+		return allNodes, warns, nil
+	}
+	// 若未解析出任何SQL，则需要重置起始位置
+	if len(stmtNodes) == 0 {
+		s.parser.lexer.stmtStartPos = 0
+	}
+	// 根据parser的解析结果，使用未被解析的部分，解析出一条不支持解析的SQL
+	var unParsedNode ast.StmtNode
+	unParsedNode, err = s.resolveSqlsByDelimiter(sql[s.parser.lexer.stmtStartPos:])
+	if err != nil {
+		return allNodes, warns, err
+	}
+	allNodes = append(allNodes, unParsedNode)
+	// 递归切分剩余SQL
+	if s.parser.lexer.stmtStartPos < len(sql) {
+		nodes, _, _ := s.SplitSqlText(sql[s.parser.lexer.stmtStartPos:], charset, collation)
+		allNodes = append(allNodes, nodes...)
+	}
+	return allNodes, warns, nil
+}
+
+func (s *splitter) resloveSqlsByParser(sql, charset, collation string) (stmtNodes []ast.StmtNode, warns []error, err error) {
+	_, warns, err = s.parser.Parse(sql, charset, collation)
+	parseResults := s.parser.result
+	s.parser.updateStartLineWithOffset(parseResults)
+	if len(parseResults) > 0 {
+		for _, stmtNode := range parseResults {
+			ast.SetFlag(stmtNode)
+		}
+		stmtNodes = append(stmtNodes, parseResults...)
+	}
+	return stmtNodes, warns, err
+}
+
+func (s *splitter) resolveSqlsByDelimiter(sql string) (stmtNode ast.StmtNode, err error) {
+	endOffset, err := s.delimiter.ScanNextEndOfSql(sql)
+	if err != nil {
+		return nil, err
+	}
+	unparsedStmtBuf := bytes.Buffer{}
+	unparsedStmtBuf.WriteString(sql[:endOffset])
+	unparsedSql := unparsedStmtBuf.String()
+	unparsedSql = strings.TrimSpace(unparsedSql)
+	if len(unparsedSql) > 0 {
+		unParsedStmt := &ast.UnparsedStmt{}
+		unParsedStmt.SetStartLine(s.parser.startLineOffset)
+		unParsedStmt.SetText(unparsedSql)
+		s.parser.lexer.stmtStartPos += endOffset
+		return unParsedStmt, nil
+	}
+	return nil, fmt.Errorf("cannot reslove unparsed SQL")
+}
+
+func (s *splitter) ProcessToExecutableNodes(allNodes []ast.StmtNode) (executableNodes []ast.StmtNode) {
+	var currentDelimiter string = DefaultDelimiterString
+	var sql string
+	for _, node := range allNodes {
+		if stmt, isUnparsed := node.(*ast.UnparsedStmt); isUnparsed {
+			if matched, delimiter := matchDelimiterCommand(stmt.Text()); matched {
+				currentDelimiter = delimiter
+				continue
+			}
+			if matched, delimiter := matchDelimiterCommandSort(stmt.Text()); matched {
+				currentDelimiter = delimiter
+				continue
+			}
+		}
+		sql = strings.TrimSuffix(node.Text(), currentDelimiter)
+		if sql == "" {
+			continue
+		}
+		node.SetText(sql)
+		executableNodes = append(executableNodes, node)
+	}
+	return executableNodes
+}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -1,0 +1,249 @@
+package parser
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestSplitter(t *testing.T) {
+	s := NewSplitter()
+	// 读取文件内容
+	testCases := []struct {
+		filePath       string
+		expectedLength int
+	}{
+		{"splitter_test_1.sql", 14},
+	}
+	for _, testCase := range testCases {
+		sqls, err := os.ReadFile(testCase.filePath)
+		if err != nil {
+			t.Fatalf("无法读取文件: %v", err)
+		}
+		splitResults, _, err := s.SplitSqlText(string(sqls), "", "")
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(splitResults) != testCase.expectedLength {
+			t.FailNow()
+		}
+		for _, result := range splitResults {
+			fmt.Print(result.Text())
+			fmt.Print("\n-----------\n")
+		}
+	}
+}
+
+func TestSplitterProcess(t *testing.T) {
+	s := NewSplitter()
+	testCases := []struct {
+		filePath       string
+		expectedLength int
+	}{
+		{"splitter_test_1.sql", 9},
+	}
+	for _, testCase := range testCases {
+		// 读取文件内容
+		sql, err := os.ReadFile(testCase.filePath)
+		if err != nil {
+			t.Fatalf("无法读取文件: %v", err)
+		}
+		splitResults, _, err := s.SplitSqlText(string(sql), "", "")
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		executableNodes := s.ProcessToExecutableNodes(splitResults)
+		for _, node := range executableNodes {
+			fmt.Println(node.Text())
+			fmt.Print("\n-----------\n")
+		}
+		if len(executableNodes) != testCase.expectedLength {
+			t.FailNow()
+		}
+	}
+}
+
+func TestMatchDelimiterCommand(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// 匹配到空字符串
+		{"DELIMITER", ""},
+		{"delimiter", ""},
+		{"DELIMITER \n 'xx'", ""}, // 不允许换行，若换行则为空字符串
+		// 一般情况
+		{"DELIMITER -- use test", "--"},
+		{"DELIMITER AbC123", "AbC123"},
+		{"delimiter     ghi789  ", "ghi789"},
+		// 使用引号，但无值
+		{"DELIMITER ''", "''"},
+		{"delimiter ``", "``"},
+		{`delimiter ""`, `""`},
+		// 使用引号，且有值
+		{`DELIMITER "s s"`, `"s s"`},
+		{`DELIMITER 'xx'`, `'xx'`},
+		{"DELIMITER `aa`", "`aa`"},
+	}
+
+	for _, tc := range testCases {
+		_, result := matchDelimiterCommand(tc.input)
+		if result != tc.expected {
+			t.Errorf("For input '%s', expected '%s', but got '%s'", tc.input, tc.expected, result)
+		}
+	}
+}
+
+func TestMatchDelimiterCommandSort(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// 匹配到空字符串
+		{`\d`, ""},
+		{`\d` + "\n 'xx'", ""}, // 不允许换行，若换行则为空字符串
+		// 一般情况
+		{`\d` + " -- use test", "--"},
+		{`\d` + " AbC123", "AbC123"},
+		{`\d` + "     ghi789  ", "ghi789"},
+		// 使用引号，但无值
+		{`\d` + " ''", "''"},
+		{`\d` + " ``", "``"},
+		{`\d` + ` ""`, `""`},
+		// 使用引号，且有值
+		{`\d` + ` "s s"`, `"s s"`},
+		{`\d` + ` 'xx'`, `'xx'`},
+		{`\d` + " `aa`", "`aa`"},
+	}
+
+	for _, tc := range testCases {
+		_, result := matchDelimiterCommandSort(tc.input)
+		if result != tc.expected {
+			t.Errorf("For input '%s', expected '%s', but got '%s'", tc.input, tc.expected, result)
+		}
+	}
+}
+
+func TestRemoveOuterQuotes(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		// 使用引号
+		{"'hello'", "hello"},
+		{`"world"`, "world"},
+		{"`go`", "go"},
+		{"foo", "foo"},
+		// 引号嵌套
+		{"``", ""},
+		{"`''`", "''"},
+		// 不使用引号包裹
+		{"'bar'baz", "'bar'baz"},
+		{`"did"did`, `"did"did`},
+		{`did`, `did`},
+	}
+
+	for _, tc := range testCases {
+		result := removeOuterQuotes(tc.input)
+		if result != tc.expected {
+			t.Errorf("removeOuterQuotes(%q) = %q, expected %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+func TestIsDelimiterReservedKeyWord(t *testing.T) {
+	tests := []struct {
+		delimiter string
+		expected  bool
+	}{
+		// 非关键字
+		{"id", false},
+		{"$$", false},
+		{";;", false},
+		{"\\", false},
+		{"Abscsd", false},
+		{"%%", false},
+		{"|", false},
+		{"%", false},
+		{"foo", false},
+		{"column1", false},
+		{"table_name", false},
+		{"_underscore", false},
+		// 关键字
+		{"&&", true},
+		{"=", true},
+		{"!=", true},
+		{"<=", true},
+		{">=", true},
+		{"||", true},
+		{"<>", true},
+		{"IN", true},
+		{"AS", true},
+		{"Update", true},
+		{"Delete", true},
+		{"not", true},
+		{"Order", true},
+		{"by", true},
+		{"Select", true},
+		{"From", true},
+		{"Where", true},
+		{"Join", true},
+		{"Inner", true},
+		{"Left", true},
+		{"Right", true},
+		{"Full", true},
+		{"Group", true},
+		{"Having", true},
+		{"Insert", true},
+		{"Into", true},
+		{"Values", true},
+		{"Create", true},
+		{"Table", true},
+		{"Alter", true},
+		{"Drop", true},
+		{"Truncate", true},
+		{"Union", true},
+		{"Exists", true},
+		{"Like", true},
+		{"Distinct", true},
+		{"And", true},
+		{"Or", true},
+		{"Limit", true},
+		{"ALL", true},
+		{"ANY", true},
+		{"BETWEEN", true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.delimiter, func(t *testing.T) {
+			result := isReservedKeyWord(test.delimiter)
+			if result != test.expected {
+				t.Errorf("isDelimiterReservedKeyWord(%s) = %v; want %v", test.delimiter, result, test.expected)
+			}
+		})
+	}
+}
+
+func TestIsCommentLikeC(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"/* This is a comment */", true},
+		{"/* comment with special chars !@#$%^&*()_+ */", true},
+		{"/* */", true},
+		{"/**/", true},
+		{"/* unclosed comment", false},
+		{"just some text", false},
+		{"// single line comment", false},
+		{"/* This is a comment */ extra text", false},
+		{" extra text /* This is a comment */", false},
+	}
+
+	for _, test := range tests {
+		result := isCommentLikeC(test.input)
+		if result != test.expected {
+			t.Errorf("For input '%s', expected %v but got %v", test.input, test.expected, result)
+		}
+	}
+}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestSplitSqlText(t *testing.T) {
-	d := NewDelimiter()
+	s := NewSplitter()
 	// 读取文件内容
 	testCases := []struct {
 		filePath       string
@@ -15,13 +15,14 @@ func TestSplitSqlText(t *testing.T) {
 	}{
 		{"splitter_test_1.sql", 20},
 		{"splitter_test_2.sql", 20},
+		{"splitter_test_3.sql", 4},
 	}
 	for _, testCase := range testCases {
 		sqls, err := os.ReadFile(testCase.filePath)
 		if err != nil {
 			t.Fatalf("无法读取文件: %v", err)
 		}
-		splitResults, err := d.SplitSqlText(string(sqls))
+		splitResults, err := s.SplitSqlText(string(sqls))
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -43,7 +44,7 @@ func TestSplitterProcess(t *testing.T) {
 		expectedLength int
 	}{
 		{"splitter_test_1.sql", 14},
-		{"splitter_test_2.sql", 14},
+		// {"splitter_test_2.sql", 14},
 	}
 	for _, testCase := range testCases {
 		// 读取文件内容
@@ -140,13 +141,13 @@ func TestIsDelimiterReservedKeyWord(t *testing.T) {
 }
 
 func TestSkipQuotedDelimiter(t *testing.T) {
-	d := NewDelimiter()
+	s := NewSplitter()
 	// 读取文件内容
 	sqls, err := os.ReadFile("splitter_test_skip_quoted_delimiter.sql")
 	if err != nil {
 		t.Fatalf("无法读取文件: %v", err)
 	}
-	splitResults, err := d.SplitSqlText(string(sqls))
+	splitResults, err := s.SplitSqlText(string(sqls))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -51,11 +51,10 @@ func TestSplitterProcess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("无法读取文件: %v", err)
 		}
-		allNodes, err := s.ParseSqlText(string(sqlText))
+		executableNodes, err := s.ParseSqlText(string(sqlText))
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		executableNodes := s.ProcessToExecutableNodes(allNodes)
 		for _, node := range executableNodes {
 			fmt.Print("\n------------------------------\n")
 			fmt.Printf("SQL语句在第%v行\n", node.StartLine())

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -725,3 +725,128 @@ func TestCharset(t *testing.T) {
 		}
 	}
 }
+
+func TestGeometryColumn(t *testing.T) {
+	parser := NewSplitter()
+	type testCase struct {
+		sql       string
+		formatSQL string
+		noError   bool
+		errMsg    string
+	}
+
+	tc := []testCase{
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,g POINT)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g POINT)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRY)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g GEOMETRY)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g LINESTRING)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g LINESTRING)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g POLYGON)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g POLYGON)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g MULTIPOINT)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g MULTIPOINT)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g MULTILINESTRING)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g MULTILINESTRING)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g MULTIPOLYGON)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g MULTIPOLYGON)`,
+			noError:   true,
+		},
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY, g GEOMETRYCOLLECTION)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,g GEOMETRYCOLLECTION)`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g GEOMETRY`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g GEOMETRY`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g POINT`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g POINT`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g LINESTRING`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g LINESTRING`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g POLYGON`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g POLYGON`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g MULTIPOINT`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g MULTIPOINT`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g MULTILINESTRING`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g MULTILINESTRING`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g MULTIPOLYGON`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g MULTIPOLYGON`,
+			noError:   true,
+		},
+		{
+			sql:       `ALTER TABLE t ADD COLUMN g GEOMETRYCOLLECTION`,
+			formatSQL: `ALTER TABLE t ADD COLUMN g GEOMETRYCOLLECTION`,
+			noError:   true,
+		},
+	}
+
+	for _, c := range tc {
+		stmts, err := parser.ParseSqlText(c.sql)
+		if err != nil {
+			if c.noError {
+				t.Error(err)
+				continue
+			}
+			if err.Error() != c.errMsg {
+				t.Errorf("expect error message: %s; actual error message: %s", c.errMsg, err.Error())
+				continue
+			}
+			continue
+		} else {
+			if !c.noError {
+				t.Errorf("expect need error, but no error")
+				continue
+			}
+			buf := new(bytes.Buffer)
+			restoreCtx := parser_formate.NewRestoreCtx(parser_formate.RestoreKeyWordUppercase, buf)
+			if len(stmts) > 0 {
+				err = stmts[0].Restore(restoreCtx)
+				if nil != err {
+					t.Error(err)
+					continue
+				}
+				if buf.String() != c.formatSQL {
+					t.Errorf("expect sql format: %s; actual sql format: %s", c.formatSQL, buf.String())
+				}
+			}
+		}
+	}
+}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -66,33 +66,6 @@ func TestSplitterProcess(t *testing.T) {
 	}
 }
 
-func TestRemoveOuterQuotes(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		// 使用引号
-		{"'hello'", "hello"},
-		{`"world"`, "world"},
-		{"`go`", "go"},
-		{"foo", "foo"},
-		// 引号嵌套
-		{"``", ""},
-		{"`''`", "''"},
-		// 不使用引号包裹
-		{"'bar'baz", "'bar'baz"},
-		{`"did"did`, `"did"did`},
-		{`did`, `did`},
-	}
-
-	for _, tc := range testCases {
-		result := removeOuterQuotes(tc.input)
-		if result != tc.expected {
-			t.Errorf("removeOuterQuotes(%q) = %q, expected %q", tc.input, result, tc.expected)
-		}
-	}
-}
-
 func TestIsDelimiterReservedKeyWord(t *testing.T) {
 	tests := []struct {
 		delimiter string
@@ -166,26 +139,23 @@ func TestIsDelimiterReservedKeyWord(t *testing.T) {
 	}
 }
 
-func TestIsCommentLikeC(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected bool
-	}{
-		{"/* This is a comment */", true},
-		{"/* comment with special chars !@#$%^&*()_+ */", true},
-		{"/* */", true},
-		{"/**/", true},
-		{"/* unclosed comment", false},
-		{"just some text", false},
-		{"// single line comment", false},
-		{"/* This is a comment */ extra text", false},
-		{" extra text /* This is a comment */", false},
+func TestSkipQuotedDelimiter(t *testing.T) {
+	d := NewDelimiter()
+	// 读取文件内容
+	sqls, err := os.ReadFile("splitter_test_skip_quoted_delimiter.sql")
+	if err != nil {
+		t.Fatalf("无法读取文件: %v", err)
 	}
-
-	for _, test := range tests {
-		result := isCommentLikeC(test.input)
-		if result != test.expected {
-			t.Errorf("For input '%s', expected %v but got %v", test.input, test.expected, result)
-		}
+	splitResults, err := d.SplitSqlText(string(sqls))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for _, result := range splitResults {
+		fmt.Print("------------------------------\n")
+		fmt.Printf("SQL语句在第%v行\n", result.line)
+		fmt.Printf("SQL语句为:\n%v\n", result.sql)
+	}
+	if len(splitResults) != 26 {
+		t.FailNow()
 	}
 }

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -160,3 +160,92 @@ func TestSkipQuotedDelimiter(t *testing.T) {
 		t.FailNow()
 	}
 }
+
+
+func TestStartLine(t *testing.T) {
+	// 测试用例第2个到第5个sql是解析器不能解析的sql
+	p := NewSplitter()
+	stmts, err := p.ParseSqlText(`grant all on point_trans_shard_00_part_202401 to kgoldpointapp;
+create table point_trans_shard_00_part_202401(like point_trans_shard_00 including all) inherits(point_trans_shard_00);
+Alter table point_trans_shard_00_part_202401 ADD CONSTRAINT chk_point_trans_shard_202401 CHECK (processedtime >= '1704038400000'::bigint AND processedtime < '1706716800000'::bigint );
+create table point_trans_source_shard_00_part_202401(like point_trans_source_shard_00 including all) inherits(point_trans_source_shard_00);
+Alter table point_trans_source_shard_00_part_202401 ADD CONSTRAINT chk_point_trans_source_shard_202401 CHECK (processedtime >= '1704038400000'::bigint AND processedtime < '1706716800000'::bigint );
+grant select on point_trans_shard_00_part_202401 to prd_fin, dbsec, sec_db_scan;
+grant all on point_trans_source_shard_00_part_202401 to kgoldpointapp;
+grant select on point_trans_source_shard_00_part_202401 to prd_fin, dbsec, sec_db_scan;
+`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(stmts) != 8 {
+		t.Errorf("expect 2 stmts, actual is %d", len(stmts))
+		return
+	}
+	for i, stmt := range stmts {
+		if stmt.StartLine() != i+1 {
+			t.Errorf("expect start line is %d, actual is %d", i+1, stmt.StartLine())
+		}
+	}
+
+	// 所有测试用例都是可以解析的sql
+	stmts, err = p.ParseSqlText(`grant select on point_trans_shard_00_part_202401 to prd_fin, dbsec, sec_db_scan;
+grant all on point_trans_source_shard_00_part_202401 to kgoldpointapp;
+grant select on point_trans_source_shard_00_part_202401 to prd_fin, dbsec, sec_db_scan;
+`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(stmts) != 3 {
+		t.Errorf("expect 3 nodes, actual is %d", len(stmts))
+		return
+	}
+	for i, node := range stmts {
+		if node.StartLine() != i+1 {
+			t.Errorf("expect start line is %d, actual is %d", i+1, node.StartLine())
+		}
+	}
+
+	// 所有测试用例都是不可以解析的sql
+	stmts, err = p.ParseSqlText(`create table point_trans_shard_00_part_202401(like point_trans_shard_00 including all) inherits(point_trans_shard_00);
+Alter table point_trans_shard_00_part_202401 ADD CONSTRAINT chk_point_trans_shard_202401 CHECK (processedtime >= '1704038400000'::bigint AND processedtime < '1706716800000'::bigint );
+create table point_trans_source_shard_00_part_202401(like point_trans_source_shard_00 including all) inherits(point_trans_source_shard_00);`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(stmts) != 3 {
+		t.Errorf("expect 3 stmts, actual is %d", len(stmts))
+		return
+	}
+	for i, stmt := range stmts {
+		if stmt.StartLine() != i+1 {
+			t.Errorf("expect start line is %d, actual is %d", i+1, stmt.StartLine())
+		}
+	}
+
+	// 并排sql测试用例,备注:3个sql都不能被解析
+	stmts, err = p.ParseSqlText(`create table point_trans_shard_00_part_202401(like point_trans_shard_00 including all) inherits(point_trans_shard_00);
+Alter table point_trans_shard_00_part_202401 ADD CONSTRAINT chk_point_trans_shard_202401 CHECK (processedtime >= '1704038400000'::bigint AND processedtime < '1706716800000'::bigint );create table point_trans_source_shard_00_part_202401(like point_trans_source_shard_00 including all) inherits(point_trans_source_shard_00);`)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if len(stmts) != 3 {
+		t.Errorf("expect 3 stmts, actual is %d", len(stmts))
+		return
+	}
+
+	for i, stmt := range stmts {
+		if i == 2 {
+			if stmt.StartLine() != 2 {
+				t.Errorf("expect start line is 2, actual is %d", stmt.StartLine())
+			}
+		} else {
+			if stmt.StartLine() != i+1 {
+				t.Errorf("expect start line is %d, actual is %d", i+1, stmt.StartLine())
+			}
+		}
+	}
+}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -13,8 +13,8 @@ func TestSplitSqlText(t *testing.T) {
 		filePath       string
 		expectedLength int
 	}{
-		{"splitter_test_1.sql", 9},
-		{"splitter_test_2.sql", 10},
+		{"splitter_test_1.sql", 20},
+		{"splitter_test_2.sql", 20},
 	}
 	for _, testCase := range testCases {
 		sqls, err := os.ReadFile(testCase.filePath)
@@ -29,9 +29,9 @@ func TestSplitSqlText(t *testing.T) {
 			t.FailNow()
 		}
 		for _, result := range splitResults {
-			fmt.Println(result.sql)
-			fmt.Println(result.line)
-			fmt.Print("\n-----------\n")
+			fmt.Print("\n------------------------------\n")
+			fmt.Printf("SQL语句在第%v行\n", result.line)
+			fmt.Printf("SQL语句为:\n%v", result.sql)
 		}
 	}
 }
@@ -42,8 +42,8 @@ func TestSplitterProcess(t *testing.T) {
 		filePath       string
 		expectedLength int
 	}{
-		{"splitter_test_1.sql", 5},
-		{"splitter_test_2.sql", 8},
+		{"splitter_test_1.sql", 14},
+		{"splitter_test_2.sql", 14},
 	}
 	for _, testCase := range testCases {
 		// 读取文件内容
@@ -57,9 +57,9 @@ func TestSplitterProcess(t *testing.T) {
 		}
 		executableNodes := s.ProcessToExecutableNodes(allNodes)
 		for _, node := range executableNodes {
-			fmt.Println(node.Text())
-			fmt.Println(node.StartLine())
-			fmt.Print("\n-----------\n")
+			fmt.Print("\n------------------------------\n")
+			fmt.Printf("SQL语句在第%v行\n", node.StartLine())
+			fmt.Printf("SQL语句为:\n%v", node.Text())
 		}
 		if len(executableNodes) != testCase.expectedLength {
 			t.FailNow()

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -921,3 +921,271 @@ func TestIndexConstraint(t *testing.T) {
 		}
 	}
 }
+
+func TestGeometryColumnIsNotReserved(t *testing.T) {
+	parser := NewSplitter()
+	type testCase struct {
+		sql       string
+		formatSQL string
+		noError   bool
+		errMsg    string
+	}
+
+	tc := []testCase{
+		// point
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,point INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,point INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT point FROM t`,
+			formatSQL: `SELECT point FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (point) VALUES (1)`,
+			formatSQL: `INSERT INTO t (point) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET point=1`,
+			formatSQL: `UPDATE t SET point=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE point=1`,
+			formatSQL: `DELETE FROM t WHERE point=1`,
+			noError:   true,
+		},
+		// geometry
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,geometry INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,geometry INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT geometry FROM t`,
+			formatSQL: `SELECT geometry FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (geometry) VALUES (1)`,
+			formatSQL: `INSERT INTO t (geometry) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET geometry=1`,
+			formatSQL: `UPDATE t SET geometry=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE geometry=1`,
+			formatSQL: `DELETE FROM t WHERE geometry=1`,
+			noError:   true,
+		},
+		// LINESTRING
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,linestring INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,linestring INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT linestring FROM t`,
+			formatSQL: `SELECT linestring FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (linestring) VALUES (1)`,
+			formatSQL: `INSERT INTO t (linestring) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET linestring=1`,
+			formatSQL: `UPDATE t SET linestring=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE linestring=1`,
+			formatSQL: `DELETE FROM t WHERE linestring=1`,
+			noError:   true,
+		},
+		// POLYGON
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,polygon INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,polygon INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT polygon FROM t`,
+			formatSQL: `SELECT polygon FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (polygon) VALUES (1)`,
+			formatSQL: `INSERT INTO t (polygon) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET polygon=1`,
+			formatSQL: `UPDATE t SET polygon=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE polygon=1`,
+			formatSQL: `DELETE FROM t WHERE polygon=1`,
+			noError:   true,
+		},
+		// MULTIPOINT
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,multipoint INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,multipoint INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT multipoint FROM t`,
+			formatSQL: `SELECT multipoint FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (multipoint) VALUES (1)`,
+			formatSQL: `INSERT INTO t (multipoint) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET multipoint=1`,
+			formatSQL: `UPDATE t SET multipoint=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE multipoint=1`,
+			formatSQL: `DELETE FROM t WHERE multipoint=1`,
+			noError:   true,
+		},
+		// MULTILINESTRING
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,multilinestring INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,multilinestring INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT multilinestring FROM t`,
+			formatSQL: `SELECT multilinestring FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (multilinestring) VALUES (1)`,
+			formatSQL: `INSERT INTO t (multilinestring) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET multilinestring=1`,
+			formatSQL: `UPDATE t SET multilinestring=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE multilinestring=1`,
+			formatSQL: `DELETE FROM t WHERE multilinestring=1`,
+			noError:   true,
+		},
+		// MULTIPOLYGON
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,multipolygon INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,multipolygon INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT multipolygon FROM t`,
+			formatSQL: `SELECT multipolygon FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (multipolygon) VALUES (1)`,
+			formatSQL: `INSERT INTO t (multipolygon) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET multipolygon=1`,
+			formatSQL: `UPDATE t SET multipolygon=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE multipolygon=1`,
+			formatSQL: `DELETE FROM t WHERE multipolygon=1`,
+			noError:   true,
+		},
+		// GEOMETRYCOLLECTION
+		{
+			sql:       `CREATE TABLE t (id INT PRIMARY KEY,geometrycollection INT(8) NOT NULL)`,
+			formatSQL: `CREATE TABLE t (id INT PRIMARY KEY,geometrycollection INT(8) NOT NULL)`,
+			noError:   true,
+		},
+		{
+			sql:       `SELECT geometrycollection FROM t`,
+			formatSQL: `SELECT geometrycollection FROM t`,
+			noError:   true,
+		},
+		{
+			sql:       `INSERT INTO t (geometrycollection) VALUES (1)`,
+			formatSQL: `INSERT INTO t (geometrycollection) VALUES (1)`,
+			noError:   true,
+		},
+		{
+			sql:       `UPDATE t SET geometrycollection=1`,
+			formatSQL: `UPDATE t SET geometrycollection=1`,
+			noError:   true,
+		},
+		{
+			sql:       `DELETE FROM t WHERE geometrycollection=1`,
+			formatSQL: `DELETE FROM t WHERE geometrycollection=1`,
+			noError:   true,
+		},
+	}
+
+	for _, c := range tc {
+		stmt, err := parser.ParseSqlText(c.sql)
+		if len(stmt) == 0 {
+			t.Fatalf("result is empty")
+		}
+		if err != nil {
+			if c.noError {
+				t.Error(err)
+				continue
+			}
+			// 现在不会报错，而是解析为为解析节点
+			// if err.Error() != c.errMsg {
+			// 	t.Errorf("expect error message: %s; actual error message: %s", c.errMsg, err.Error())
+			// 	continue
+			// }
+			if _, ok := stmt[0].(*ast.UnparsedStmt); !ok {
+				t.Errorf("expect error message: %s; actual error message: %s", c.errMsg, err.Error())
+				continue
+			}
+			// if err.Error() != c.errMsg {
+			// 	t.Errorf("expect error message: %s; actual error message: %s", c.errMsg, err.Error())
+			// 	continue
+			// }
+			continue
+		} else {
+			if !c.noError {
+				// t.Errorf("expect need error, but no error")
+				if _, ok := stmt[0].(*ast.UnparsedStmt); !ok {
+					t.Errorf("expect error message: %s; actual error message: %s", c.errMsg, err.Error())
+					continue
+				}
+				continue
+			}
+			buf := new(bytes.Buffer)
+			restoreCtx := parser_formate.NewRestoreCtx(parser_formate.RestoreKeyWordUppercase, buf)
+
+			err = stmt[0].Restore(restoreCtx)
+			if nil != err {
+				t.Error(err)
+				continue
+			}
+			if buf.String() != c.formatSQL {
+				t.Errorf("expect sql format: %s; actual sql format: %s", c.formatSQL, buf.String())
+			}
+		}
+	}
+}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -22,7 +22,7 @@ func TestSplitSqlText(t *testing.T) {
 		if err != nil {
 			t.Fatalf("无法读取文件: %v", err)
 		}
-		splitResults, err := s.SplitSqlText(string(sqls))
+		splitResults, err := s.splitSqlText(string(sqls))
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -147,7 +147,7 @@ func TestSkipQuotedDelimiter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("无法读取文件: %v", err)
 	}
-	splitResults, err := s.SplitSqlText(string(sqls))
+	splitResults, err := s.splitSqlText(string(sqls))
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 )
 
-func TestSplitter(t *testing.T) {
-	s := NewSplitter()
+func TestSplitSqlText(t *testing.T) {
+	d := NewDelimiter()
 	// 读取文件内容
 	testCases := []struct {
 		filePath       string
 		expectedLength int
 	}{
-		{"splitter_test_1.sql", 14},
+		{"splitter_test_1.sql", 9},
 		{"splitter_test_2.sql", 10},
 	}
 	for _, testCase := range testCases {
@@ -21,7 +21,7 @@ func TestSplitter(t *testing.T) {
 		if err != nil {
 			t.Fatalf("无法读取文件: %v", err)
 		}
-		splitResults, _, err := s.SplitSqlText(string(sqls), "", "")
+		splitResults, err := d.SplitSqlText(string(sqls))
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -29,7 +29,8 @@ func TestSplitter(t *testing.T) {
 			t.FailNow()
 		}
 		for _, result := range splitResults {
-			fmt.Print(result.Text())
+			fmt.Println(result.sql)
+			fmt.Println(result.line)
 			fmt.Print("\n-----------\n")
 		}
 	}
@@ -41,22 +42,23 @@ func TestSplitterProcess(t *testing.T) {
 		filePath       string
 		expectedLength int
 	}{
-		{"splitter_test_1.sql", 9},
+		{"splitter_test_1.sql", 5},
 		{"splitter_test_2.sql", 8},
 	}
 	for _, testCase := range testCases {
 		// 读取文件内容
-		sql, err := os.ReadFile(testCase.filePath)
+		sqlText, err := os.ReadFile(testCase.filePath)
 		if err != nil {
 			t.Fatalf("无法读取文件: %v", err)
 		}
-		splitResults, _, err := s.SplitSqlText(string(sql), "", "")
+		allNodes, err := s.ParseSqlText(string(sqlText))
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		executableNodes := s.ProcessToExecutableNodes(splitResults)
+		executableNodes := s.ProcessToExecutableNodes(allNodes)
 		for _, node := range executableNodes {
 			fmt.Println(node.Text())
+			fmt.Println(node.StartLine())
 			fmt.Print("\n-----------\n")
 		}
 		if len(executableNodes) != testCase.expectedLength {

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -14,6 +14,7 @@ func TestSplitter(t *testing.T) {
 		expectedLength int
 	}{
 		{"splitter_test_1.sql", 14},
+		{"splitter_test_2.sql", 10},
 	}
 	for _, testCase := range testCases {
 		sqls, err := os.ReadFile(testCase.filePath)
@@ -41,6 +42,7 @@ func TestSplitterProcess(t *testing.T) {
 		expectedLength int
 	}{
 		{"splitter_test_1.sql", 9},
+		{"splitter_test_2.sql", 8},
 	}
 	for _, testCase := range testCases {
 		// 读取文件内容

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -67,67 +67,6 @@ func TestSplitterProcess(t *testing.T) {
 	}
 }
 
-func TestMatchDelimiterCommand(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		// 匹配到空字符串
-		{"DELIMITER", ""},
-		{"delimiter", ""},
-		{"DELIMITER \n 'xx'", ""}, // 不允许换行，若换行则为空字符串
-		// 一般情况
-		{"DELIMITER -- use test", "--"},
-		{"DELIMITER AbC123", "AbC123"},
-		{"delimiter     ghi789  ", "ghi789"},
-		// 使用引号，但无值
-		{"DELIMITER ''", "''"},
-		{"delimiter ``", "``"},
-		{`delimiter ""`, `""`},
-		// 使用引号，且有值
-		{`DELIMITER "s s"`, `"s s"`},
-		{`DELIMITER 'xx'`, `'xx'`},
-		{"DELIMITER `aa`", "`aa`"},
-	}
-
-	for _, tc := range testCases {
-		_, result := matchDelimiterCommand(tc.input)
-		if result != tc.expected {
-			t.Errorf("For input '%s', expected '%s', but got '%s'", tc.input, tc.expected, result)
-		}
-	}
-}
-
-func TestMatchDelimiterCommandSort(t *testing.T) {
-	testCases := []struct {
-		input    string
-		expected string
-	}{
-		// 匹配到空字符串
-		{`\d`, ""},
-		{`\d` + "\n 'xx'", ""}, // 不允许换行，若换行则为空字符串
-		// 一般情况
-		{`\d` + " -- use test", "--"},
-		{`\d` + " AbC123", "AbC123"},
-		{`\d` + "     ghi789  ", "ghi789"},
-		// 使用引号，但无值
-		{`\d` + " ''", "''"},
-		{`\d` + " ``", "``"},
-		{`\d` + ` ""`, `""`},
-		// 使用引号，且有值
-		{`\d` + ` "s s"`, `"s s"`},
-		{`\d` + ` 'xx'`, `'xx'`},
-		{`\d` + " `aa`", "`aa`"},
-	}
-
-	for _, tc := range testCases {
-		_, result := matchDelimiterCommandSort(tc.input)
-		if result != tc.expected {
-			t.Errorf("For input '%s', expected '%s', but got '%s'", tc.input, tc.expected, result)
-		}
-	}
-}
-
 func TestRemoveOuterQuotes(t *testing.T) {
 	testCases := []struct {
 		input    string

--- a/splitter_test_1.sql
+++ b/splitter_test_1.sql
@@ -1,0 +1,20 @@
+DELIMITER --good
+
+USE `fwdb`--good
+-- sasa
+DROP PROCEDURE IF EXISTS `_GS_GM_Check` --good
+CREATE DEFINER=`root`@`%` PROCEDURE `_GS_GM_Check`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
+BEGIN
+	-- JinSQ 2016-04-08 CHECK IP ADD END
+    END--good
+
+DELIMITER ;
+DELIMITER //
+use test //
+SET @sql = 'SELECT * FROM employees WHERE salary = 2321.21';
+SET @result = @sql;
+PREPARE stmt FROM @result;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+//
+DELIMITER ;

--- a/splitter_test_1.sql
+++ b/splitter_test_1.sql
@@ -1,20 +1,61 @@
+/* DELIMITER str */
+/* 注释中定义分隔符 预期不会被检测为分隔符语法 */
 DELIMITER --good
+-- DELIMITER str
 
-USE `fwdb`--good
--- sasa
+/* 分隔符在注释中，预期不被分割 */
+-- --good
+/* --good */
 DROP PROCEDURE IF EXISTS `_GS_GM_Check` --good
-CREATE DEFINER=`root`@`%` PROCEDURE `_GS_GM_Check`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
+/* 分隔符在SQL语句中或注释中，预期不会被分割 */
+/* 分隔符定义语法在SQL语句中，预期不会被识别 */
+CREATE DELIMITER = `--good`@`%` PROCEDURE `DELIMITER`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
 BEGIN
-	-- JinSQ 2016-04-08 CHECK IP ADD END
+/* 分隔符与语句粘连，预期会被分割 */
     END--good
-
+/* 切换分隔符 */
 DELIMITER ;
+CREATE FUNCTION hello (s CHAR(20));
+CREATE FUNCTION hello (s CHAR(20)) ;
+-- 切换分隔符
 DELIMITER //
 use test //
+/* 多条语句合并提交，预期切分结果会包含分隔符之间的多条sql */
 SET @sql = 'SELECT * FROM employees WHERE salary = 2321.21';
 SET @result = @sql;
 PREPARE stmt FROM @result;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
+CREATE DELIMITER = `//`@`%` PROCEDURE `DELIMITER`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
+BEGIN
+    -- 分隔符与语句粘连，预期会被分割
+    END;
 //
 DELIMITER ;
+
+CREATE TABLE account (acct_num INT, amount DECIMAL(10,2)); /* ; */
+
+CREATE TRIGGER ins_sum BEFORE /* ; */INSERT ON account
+       FOR EACH ROW SET @sum = @sum + NEW.amount;
+
+SET @sum = 0;
+
+INSERT INTO account VALUES(137,14.98)/* ; */,(141,1937.50),(97,-100.00);/* ; */
+SELECT @sum AS ';';/* ; */
+DROP TRIGGER test.ins_sum;/* ; */
+CREATE TRIGGER ins_transaction BEFORE INSERT ON account
+    /* ; */  FOR EACH ROW PRECEDES ins_sum
+       SET
+       @deposits = @deposits + IF(NEW.amount>0,NEW.amount,0),
+       @withdrawals = @withdrawals + IF(NEW.amount<0,-NEW.amount,0);
+delimiter //
+CREATE TRIGGER upd_check BEFORE UPDATE ON account
+       FOR EACH ROW
+       BEGIN
+           IF NEW.amount < 0 THEN
+               SET NEW.amount = 0;
+           ELSEIF NEW.amount > 100 THEN
+               SET NEW.amount = 100;
+           END IF;
+       END//
+delimiter ;

--- a/splitter_test_2.sql
+++ b/splitter_test_2.sql
@@ -1,0 +1,24 @@
+
+CREATE TABLE account (acct_num INT, amount DECIMAL(10,2));
+CREATE TRIGGER ins_sum BEFORE INSERT ON account
+       FOR EACH ROW SET @sum = @sum + NEW.amount;
+SET @sum = 0;
+INSERT INTO account VALUES(137,14.98),(141,1937.50),(97,-100.00);
+SELECT @sum AS 'Total amount inserted';
+DROP TRIGGER test.ins_sum;
+REATE TRIGGER ins_transaction BEFORE INSERT ON account
+       FOR EACH ROW PRECEDES ins_sum
+       SET
+       @deposits = @deposits + IF(NEW.amount>0,NEW.amount,0),
+       @withdrawals = @withdrawals + IF(NEW.amount<0,-NEW.amount,0);
+delimiter //
+CREATE TRIGGER upd_check BEFORE UPDATE ON account
+       FOR EACH ROW
+       BEGIN
+           IF NEW.amount < 0 THEN
+               SET NEW.amount = 0;
+           ELSEIF NEW.amount > 100 THEN
+               SET NEW.amount = 100;
+           END IF;
+       END;//
+delimiter ;

--- a/splitter_test_2.sql
+++ b/splitter_test_2.sql
@@ -1,13 +1,50 @@
+/* \d str */
+/* 注释中定义分隔符 预期不会被检测为分隔符语法 */
+\d --good
+-- \d str
 
-CREATE TABLE account (acct_num INT, amount DECIMAL(10,2));
-CREATE TRIGGER ins_sum BEFORE INSERT ON account
+/* 分隔符在注释中，预期不被分割 */
+-- --good
+/* --good */
+DROP PROCEDURE IF EXISTS `_GS_GM_Check` --good
+/* 分隔符在SQL语句中或注释中，预期不会被分割 */
+/* 分隔符定义语法在SQL语句中，预期不会被识别 */
+CREATE \d = `--good`@`%` PROCEDURE `\d`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
+BEGIN
+/* 分隔符与语句粘连，预期会被分割 */
+    END--good
+/* 切换分隔符 */
+\d ;
+CREATE FUNCTION hello (s CHAR(20));
+CREATE FUNCTION hello (s CHAR(20)) ;
+-- 切换分隔符
+\d //
+use test //
+/* 多条语句合并提交，预期切分结果会包含分隔符之间的多条sql */
+SET @sql = 'SELECT * FROM employees WHERE salary = 2321.21';
+SET @result = @sql;
+PREPARE stmt FROM @result;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+CREATE \d = `//`@`%` PROCEDURE `\d`(vi_uid INT,vi_pwd VARCHAR(32),vi_ip VARCHAR(100),OUT vo_level INT,OUT vo_code INT)
+BEGIN
+    -- 分隔符与语句粘连，预期会被分割
+    END;
+//
+\d ;
+
+CREATE TABLE account (acct_num INT, amount DECIMAL(10,2)); /* ; */
+
+CREATE TRIGGER ins_sum BEFORE /* ; */INSERT ON account
        FOR EACH ROW SET @sum = @sum + NEW.amount;
+
 SET @sum = 0;
-INSERT INTO account VALUES(137,14.98),(141,1937.50),(97,-100.00);
-SELECT @sum AS 'Total amount inserted';
-DROP TRIGGER test.ins_sum;
-REATE TRIGGER ins_transaction BEFORE INSERT ON account
-       FOR EACH ROW PRECEDES ins_sum
+
+INSERT INTO account VALUES(137,14.98)/* ; */,(141,1937.50),(97,-100.00);/* ; */
+SELECT @sum AS ';';/* ; */
+DROP TRIGGER test.ins_sum;/* ; */
+CREATE TRIGGER ins_transaction BEFORE INSERT ON account
+    /* ; */  FOR EACH ROW PRECEDES ins_sum
        SET
        @deposits = @deposits + IF(NEW.amount>0,NEW.amount,0),
        @withdrawals = @withdrawals + IF(NEW.amount<0,-NEW.amount,0);
@@ -20,5 +57,5 @@ CREATE TRIGGER upd_check BEFORE UPDATE ON account
            ELSEIF NEW.amount > 100 THEN
                SET NEW.amount = 100;
            END IF;
-       END;//
+       END//
 delimiter ;

--- a/splitter_test_3.sql
+++ b/splitter_test_3.sql
@@ -1,0 +1,83 @@
+-- 1
+CREATE PROCEDURE nested_example()
+BEGIN
+    DECLARE v_outer_variable INT DEFAULT 0;
+
+    -- 外层 BEGIN ... END 块
+    BEGIN
+        DECLARE v_inner_variable INT DEFAULT 10;
+
+        -- 内层 BEGIN ... END 块
+        BEGIN
+            DECLARE v_nested_variable INT DEFAULT 20;
+            
+            IF v_outer_variable = 0 THEN
+                SET v_outer_variable = v_inner_variable + v_nested_variable;
+            END IF;
+        END; -- 内层块结束
+        WHILE v1 > 0 DO
+            SET v1 = v1 - 1;
+        END WHILE;
+        IF v_outer_variable > 0 THEN
+            SET v_outer_variable = v_outer_variable * 2;
+        END IF;
+    END; -- 外层块结束
+END;
+-- 2
+CREATE PROCEDURE example_procedure()
+BEGIN
+    DECLARE v_variable INT DEFAULT 0;
+    
+    IF v_variable = 0 THEN
+        SET v_variable = 1;
+    ELSEIF v_variable = 1 THEN
+        SET v_variable = 2;
+    ELSE
+        SET v_variable = 0;
+    END IF;
+    
+    -- 其他处理语句
+END;
+-- 3
+CREATE PROCEDURE doiterate(p1 INT)
+BEGIN
+  label1: LOOP
+    SET p1 = p1 + 1;
+    IF p1 < 10 THEN
+      ITERATE label1;
+    END IF;
+    LEAVE label1;
+  END LOOP label1;
+  SET @x = p1;
+END;
+-- 4
+CREATE PROCEDURE complex_loops_example()
+BEGIN
+    DECLARE v_counter INT DEFAULT 0;
+    DECLARE v_limit INT DEFAULT 5;
+    DECLARE v_sum INT DEFAULT 0;
+
+    -- 使用 LOOP 结构
+    loop_label: LOOP
+        SET v_counter = v_counter + 1;
+        
+        -- 使用 WHILE 结构
+        WHILE v_counter <= v_limit DO
+            SET v_sum = v_sum + v_counter;
+            
+            -- 使用 REPEAT 结构
+            REPEAT
+                SET v_counter = v_counter + 1;
+            UNTIL v_counter > v_limit
+            END REPEAT;
+        END WHILE;
+
+        -- 退出 LOOP 的条件
+        IF v_counter > v_limit THEN
+            LEAVE loop_label;
+        END IF;
+    END LOOP;
+
+    -- 输出结果
+    SELECT v_sum AS total_sum;
+END;

--- a/splitter_test_skip_quoted_delimiter.sql
+++ b/splitter_test_skip_quoted_delimiter.sql
@@ -1,0 +1,26 @@
+delimiter abcd
+select `abcd` abcd
+select "abcd" abcd
+select 'abcd' abcd
+delimiter "'abcd'"
+select `'abcd'` 'abcd'
+select "'abcd'" 'abcd'
+delimiter "`abcd`"
+select '`abcd`' `abcd`
+select "`abcd`" `abcd`
+delimiter `"abcd"`
+select '"abcd"' "abcd"
+select `"abcd"` "abcd"
+delimiter `"abcd";`
+select '"abcd";' "abcd";
+select `"abcd";` "abcd";
+delimiter "`abcd`;"
+select "`abcd`;" `abcd`;
+select '`abcd`;' `abcd`;
+delimiter "'abcd';"
+select "'abcd';" 'abcd';
+select `'abcd';` 'abcd';
+delimiter ab
+select "ab'abcd';" ab
+select `ab'abcd';` ab
+select `abcd`; ab


### PR DESCRIPTION
## 关联的 issue
https://github.com/actiontech/sqle/issues/2406
## 描述你的变更

1. 新增对象delimiter，用于匹配delimiter定义语句，匹配sql文本中的分隔符
2. 新增对象splitter，用于分割sql文本至sql，
    1. splitter中的方法SplitSqlText，将sql文本切分成一条条sql，保留sql本身，不会去除自定义的分隔符
    2. splitter中的方法ProcessToExecutableNodes，用于将自定义分隔符从sql语句结尾去除，去除分隔符定义语句，剩余的sql是可以执行的sql
3. 为splitter和delimiter中的一些方法和函数创建了单元测试

## 后续工作

- [x] 确认sql行数正确性
- [x] 增加更多的单测

## 确认项（pr提交后操作）
> [!TIP]
> 请在指定**复审人**之前，确认并完成以下事项，完成后✅
----------------------------------------------------------------------
- [x] 我已完成自测
- [ ] 我已在关联的issue里补充了实现方案
- [ ] 我已在关联的issue里补充了测试影响面
- [x] 我已确认了变更的兼容性，如果不兼容则在issue里标记 `not_compatible`
- [x] 我已确认了是否要更新文档，如果要更新则在issue里标记 `need_update_doc`
----------------------------------------------------------------------
